### PR TITLE
Add multi-outcome market support in frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,9 @@ import { OraclePage } from './pages/OraclePage';
 import { LiquidityPage } from './pages/LiquidityPage';
 import { AnalyticsPage } from './pages/AnalyticsPage';
 import { LeaderboardPage } from './pages/LeaderboardPage';
+import { MultiMarketsPage } from './pages/MultiMarketsPage';
+import { MultiTradePage } from './pages/MultiTradePage';
+import { CreateMultiMarketPage } from './pages/CreateMultiMarketPage';
 
 function App() {
   return (
@@ -95,6 +98,21 @@ function App() {
                   <Route path="/leaderboard" element={
                     <PageErrorBoundary pageName="Leaderboard">
                       <LeaderboardPage />
+                    </PageErrorBoundary>
+                  } />
+                  <Route path="/multi-markets" element={
+                    <PageErrorBoundary pageName="Multi Markets">
+                      <MultiMarketsPage />
+                    </PageErrorBoundary>
+                  } />
+                  <Route path="/multi-trade/:id" element={
+                    <PageErrorBoundary pageName="Multi Trade">
+                      <MultiTradePage />
+                    </PageErrorBoundary>
+                  } />
+                  <Route path="/create-multi-market" element={
+                    <PageErrorBoundary pageName="Create Multi Market">
+                      <CreateMultiMarketPage />
                     </PageErrorBoundary>
                   } />
                 </Routes>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -18,6 +18,7 @@ export function Header() {
     { path: '/markets', label: 'Markets' },
     { path: '/create-market', label: 'Create', highlight: true },
     { path: '/portfolio', label: 'Portfolio' },
+    { path: '/multi-markets', label: 'Multi Markets' },
     { path: '/liquidity', label: 'Liquidity' },
     { path: '/analytics', label: 'Analytics' },
     { path: '/transactions', label: 'Activity' },

--- a/frontend/src/components/MobileBottomNav.tsx
+++ b/frontend/src/components/MobileBottomNav.tsx
@@ -55,6 +55,15 @@ export function MobileBottomNav() {
         </svg>
       ),
     },
+    {
+      path: '/multi-markets',
+      label: 'Multi',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h13M8 12h13M8 17h13M3 7h.01M3 12h.01M3 17h.01" />
+        </svg>
+      ),
+    },
   ];
 
   return (

--- a/frontend/src/config/contracts.ts
+++ b/frontend/src/config/contracts.ts
@@ -129,3 +129,16 @@ export const TOKEN_CONTRACT = {
     return getContractIdentifier(CONTRACT_NAMES.OXCAST);
   },
 } as const;
+
+// Multi-outcome market contract configuration
+export const MARKET_MULTI_CONTRACT = {
+  get address() {
+    return getContractAddress(CONTRACT_NAMES.MARKET_MULTI);
+  },
+  get name() {
+    return CONTRACT_NAMES.MARKET_MULTI;
+  },
+  get identifier() {
+    return getContractIdentifier(CONTRACT_NAMES.MARKET_MULTI);
+  },
+} as const;

--- a/frontend/src/hooks/useMultiMarketCreation.ts
+++ b/frontend/src/hooks/useMultiMarketCreation.ts
@@ -3,7 +3,7 @@ import { openContractCall } from '@stacks/connect';
 import { uintCV, stringUtf8CV, listCV, PostConditionMode } from '@stacks/transactions';
 import { useWallet } from '../components/WalletProvider';
 import { useNetwork } from '../contexts/NetworkContext';
-import { CONTRACT_NAMES, getContractAddress } from '../config/contracts';
+import { MARKET_MULTI_CONTRACT } from '../config/contracts';
 
 export interface CreateMultiMarketInput {
   question: string;
@@ -28,7 +28,7 @@ const initialState: MultiMarketCreationState = {
 
 export function useMultiMarketCreation() {
   const { isConnected } = useWallet();
-  const { network, stacksNetwork } = useNetwork();
+  const { stacksNetwork } = useNetwork();
   const [state, setState] = useState<MultiMarketCreationState>(initialState);
 
   const createMultiMarket = useCallback(
@@ -51,11 +51,10 @@ export function useMultiMarketCreation() {
       setState({ ...initialState, isCreating: true });
 
       try {
-        const contractAddress = getContractAddress(CONTRACT_NAMES.MARKET_MULTI, network);
         await openContractCall({
           network: stacksNetwork,
-          contractAddress,
-          contractName: CONTRACT_NAMES.MARKET_MULTI,
+          contractAddress: MARKET_MULTI_CONTRACT.address,
+          contractName: MARKET_MULTI_CONTRACT.name,
           functionName: 'create-multi-market',
           functionArgs: [
             stringUtf8CV(input.question),
@@ -81,7 +80,7 @@ export function useMultiMarketCreation() {
         });
       }
     },
-    [isConnected, network, stacksNetwork]
+    [isConnected, stacksNetwork]
   );
 
   const resetState = useCallback(() => {

--- a/frontend/src/hooks/useMultiMarketCreation.ts
+++ b/frontend/src/hooks/useMultiMarketCreation.ts
@@ -33,13 +33,27 @@ export function useMultiMarketCreation() {
 
   const createMultiMarket = useCallback(
     async (input: CreateMultiMarketInput) => {
+      const question = input.question.trim();
+      const outcomes = input.outcomes.map((value) => value.trim()).filter(Boolean);
+
       if (!isConnected) {
         setState({ ...initialState, error: 'Wallet not connected' });
         return;
       }
 
-      if (input.outcomes.length < 3 || input.outcomes.length > 10) {
+      if (question.length < 10) {
+        setState({ ...initialState, error: 'Question must be at least 10 characters' });
+        return;
+      }
+
+      if (outcomes.length < 3 || outcomes.length > 10) {
         setState({ ...initialState, error: 'Outcomes must be between 3 and 10' });
+        return;
+      }
+
+      const normalized = outcomes.map((value) => value.toLowerCase());
+      if (new Set(normalized).size !== normalized.length) {
+        setState({ ...initialState, error: 'Outcomes must be unique' });
         return;
       }
 
@@ -57,8 +71,8 @@ export function useMultiMarketCreation() {
           contractName: MARKET_MULTI_CONTRACT.name,
           functionName: 'create-multi-market',
           functionArgs: [
-            stringUtf8CV(input.question),
-            listCV(input.outcomes.map((outcome) => stringUtf8CV(outcome))),
+            stringUtf8CV(question),
+            listCV(outcomes.map((outcome) => stringUtf8CV(outcome))),
             uintCV(input.endDate),
             uintCV(input.resolutionDate),
           ],

--- a/frontend/src/hooks/useMultiMarketCreation.ts
+++ b/frontend/src/hooks/useMultiMarketCreation.ts
@@ -1,0 +1,92 @@
+import { useState, useCallback } from 'react';
+import { openContractCall } from '@stacks/connect';
+import { uintCV, stringUtf8CV, listCV, PostConditionMode } from '@stacks/transactions';
+import { useWallet } from '../components/WalletProvider';
+import { useNetwork } from '../contexts/NetworkContext';
+import { CONTRACT_NAMES, getContractAddress } from '../config/contracts';
+
+export interface CreateMultiMarketInput {
+  question: string;
+  outcomes: string[];
+  endDate: number;
+  resolutionDate: number;
+}
+
+interface MultiMarketCreationState {
+  isCreating: boolean;
+  error: string | null;
+  success: boolean;
+  txId: string | null;
+}
+
+const initialState: MultiMarketCreationState = {
+  isCreating: false,
+  error: null,
+  success: false,
+  txId: null,
+};
+
+export function useMultiMarketCreation() {
+  const { isConnected } = useWallet();
+  const { network, stacksNetwork } = useNetwork();
+  const [state, setState] = useState<MultiMarketCreationState>(initialState);
+
+  const createMultiMarket = useCallback(
+    async (input: CreateMultiMarketInput) => {
+      if (!isConnected) {
+        setState({ ...initialState, error: 'Wallet not connected' });
+        return;
+      }
+
+      if (input.outcomes.length < 3 || input.outcomes.length > 10) {
+        setState({ ...initialState, error: 'Outcomes must be between 3 and 10' });
+        return;
+      }
+
+      if (input.endDate >= input.resolutionDate) {
+        setState({ ...initialState, error: 'Resolution date must be after end date' });
+        return;
+      }
+
+      setState({ ...initialState, isCreating: true });
+
+      try {
+        const contractAddress = getContractAddress(CONTRACT_NAMES.MARKET_MULTI, network);
+        await openContractCall({
+          network: stacksNetwork,
+          contractAddress,
+          contractName: CONTRACT_NAMES.MARKET_MULTI,
+          functionName: 'create-multi-market',
+          functionArgs: [
+            stringUtf8CV(input.question),
+            listCV(input.outcomes.map((outcome) => stringUtf8CV(outcome))),
+            uintCV(input.endDate),
+            uintCV(input.resolutionDate),
+          ],
+          postConditionMode: PostConditionMode.Allow,
+          postConditions: [],
+          onFinish: (data) => {
+            setState({ isCreating: false, error: null, success: true, txId: data.txId });
+          },
+          onCancel: () => {
+            setState({ isCreating: false, error: 'Transaction cancelled', success: false, txId: null });
+          },
+        });
+      } catch (error) {
+        setState({
+          isCreating: false,
+          error: error instanceof Error ? error.message : 'Failed to create multi-outcome market',
+          success: false,
+          txId: null,
+        });
+      }
+    },
+    [isConnected, network, stacksNetwork]
+  );
+
+  const resetState = useCallback(() => {
+    setState(initialState);
+  }, []);
+
+  return { createMultiMarket, state, resetState };
+}

--- a/frontend/src/hooks/useMultiMarkets.ts
+++ b/frontend/src/hooks/useMultiMarkets.ts
@@ -1,12 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import { cvToJSON, fetchCallReadOnlyFunction, uintCV } from '@stacks/transactions';
 import { useNetwork } from '../contexts/NetworkContext';
-import { CONTRACT_NAMES, getContractAddress } from '../config/contracts';
+import { MARKET_MULTI_CONTRACT } from '../config/contracts';
 import type { MultiMarket } from '../types/market';
 import { parseMultiMarketData } from '../utils/multiMarket';
 
 export function useMultiMarkets() {
-  const { stacksNetwork, network } = useNetwork();
+  const { stacksNetwork } = useNetwork();
   const [markets, setMarkets] = useState<MultiMarket[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -14,8 +14,8 @@ export function useMultiMarkets() {
   const fetchMarkets = useCallback(async () => {
     try {
       setIsLoading(true);
-      const contractAddress = getContractAddress(CONTRACT_NAMES.MARKET_MULTI, network);
-      const contractName = CONTRACT_NAMES.MARKET_MULTI;
+      const contractAddress = MARKET_MULTI_CONTRACT.address;
+      const contractName = MARKET_MULTI_CONTRACT.name;
 
       const counter = await fetchCallReadOnlyFunction({
         network: stacksNetwork,
@@ -66,7 +66,7 @@ export function useMultiMarkets() {
     } finally {
       setIsLoading(false);
     }
-  }, [network, stacksNetwork]);
+  }, [stacksNetwork]);
 
   useEffect(() => {
     fetchMarkets();

--- a/frontend/src/hooks/useMultiMarkets.ts
+++ b/frontend/src/hooks/useMultiMarkets.ts
@@ -1,0 +1,76 @@
+import { useState, useEffect, useCallback } from 'react';
+import { cvToJSON, fetchCallReadOnlyFunction, uintCV } from '@stacks/transactions';
+import { useNetwork } from '../contexts/NetworkContext';
+import { CONTRACT_NAMES, getContractAddress } from '../config/contracts';
+import type { MultiMarket } from '../types/market';
+import { parseMultiMarketData } from '../utils/multiMarket';
+
+export function useMultiMarkets() {
+  const { stacksNetwork, network } = useNetwork();
+  const [markets, setMarkets] = useState<MultiMarket[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMarkets = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const contractAddress = getContractAddress(CONTRACT_NAMES.MARKET_MULTI, network);
+      const contractName = CONTRACT_NAMES.MARKET_MULTI;
+
+      const counter = await fetchCallReadOnlyFunction({
+        network: stacksNetwork,
+        contractAddress,
+        contractName,
+        functionName: 'get-multi-market-counter',
+        functionArgs: [],
+        senderAddress: contractAddress,
+      });
+
+      const counterJson = cvToJSON(counter);
+      if (counterJson.type !== 'response' || counterJson.value?.type !== 'uint') {
+        throw new Error('Unexpected multi-market counter response');
+      }
+
+      const totalMarkets = Number(counterJson.value.value);
+      if (totalMarkets === 0) {
+        setMarkets([]);
+        setError(null);
+        return;
+      }
+
+      const requests = Array.from({ length: totalMarkets }, (_, index) =>
+        fetchCallReadOnlyFunction({
+          network: stacksNetwork,
+          contractAddress,
+          contractName,
+          functionName: 'get-multi-market',
+          functionArgs: [uintCV(index + 1)],
+          senderAddress: contractAddress,
+        })
+      );
+
+      const responses = await Promise.all(requests);
+      const parsed: MultiMarket[] = [];
+
+      responses.forEach((response, idx) => {
+        const json = cvToJSON(response);
+        if (json.type === 'some' && json.value) {
+          parsed.push(parseMultiMarketData(idx + 1, json.value));
+        }
+      });
+
+      setMarkets(parsed);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch multi-outcome markets');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [network, stacksNetwork]);
+
+  useEffect(() => {
+    fetchMarkets();
+  }, [fetchMarkets]);
+
+  return { markets, isLoading, error, refetch: fetchMarkets };
+}

--- a/frontend/src/hooks/useMultiMarkets.ts
+++ b/frontend/src/hooks/useMultiMarkets.ts
@@ -59,6 +59,7 @@ export function useMultiMarkets() {
         }
       });
 
+      parsed.sort((a, b) => b.createdAt - a.createdAt);
       setMarkets(parsed);
       setError(null);
     } catch (err) {

--- a/frontend/src/hooks/useMultiStake.ts
+++ b/frontend/src/hooks/useMultiStake.ts
@@ -1,0 +1,97 @@
+import { useState, useCallback } from 'react';
+import { openContractCall } from '@stacks/connect';
+import { uintCV, PostConditionMode, Pc } from '@stacks/transactions';
+import { stxToMicroStx, MIN_STAKE, MAX_STAKE } from '../constants';
+import { useWallet } from '../components/WalletProvider';
+import { useNetwork } from '../contexts/NetworkContext';
+import { CONTRACT_NAMES, getContractAddress } from '../config/contracts';
+import { validateAmount, validateMarketId } from '../utils/validation';
+
+interface UseMultiStakeReturn {
+  placeOutcomeStake: (
+    marketId: number,
+    outcomeIndex: number,
+    amount: number,
+    onSuccess?: () => void
+  ) => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+  txId: string | null;
+  reset: () => void;
+}
+
+export function useMultiStake(): UseMultiStakeReturn {
+  const { address } = useWallet();
+  const { stacksNetwork, network } = useNetwork();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [txId, setTxId] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setIsLoading(false);
+    setError(null);
+    setTxId(null);
+  }, []);
+
+  const placeOutcomeStake = useCallback(
+    async (marketId: number, outcomeIndex: number, amount: number, onSuccess?: () => void) => {
+      if (!address) {
+        setError('Wallet not connected');
+        return;
+      }
+
+      const marketIdValidation = validateMarketId(marketId);
+      if (!marketIdValidation.isValid) {
+        setError(marketIdValidation.error || 'Invalid market ID');
+        return;
+      }
+
+      if (!Number.isInteger(outcomeIndex) || outcomeIndex < 0) {
+        setError('Invalid outcome index');
+        return;
+      }
+
+      const amountValidation = validateAmount(amount, MIN_STAKE, MAX_STAKE);
+      if (!amountValidation.isValid) {
+        setError(amountValidation.error || 'Invalid stake amount');
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+      setTxId(null);
+
+      try {
+        const stakeMicroStx = stxToMicroStx(amount);
+        const contractAddress = getContractAddress(CONTRACT_NAMES.MARKET_MULTI, network);
+
+        const postConditions = [Pc.principal(address).willSendEq(stakeMicroStx).ustx()];
+
+        await openContractCall({
+          network: stacksNetwork,
+          contractAddress,
+          contractName: CONTRACT_NAMES.MARKET_MULTI,
+          functionName: 'stake-on-outcome',
+          functionArgs: [uintCV(marketId), uintCV(outcomeIndex), uintCV(stakeMicroStx)],
+          postConditionMode: PostConditionMode.Deny,
+          postConditions,
+          onFinish: (data) => {
+            setTxId(data.txId);
+            setIsLoading(false);
+            onSuccess?.();
+          },
+          onCancel: () => {
+            setError('Transaction cancelled');
+            setIsLoading(false);
+          },
+        });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to place stake');
+        setIsLoading(false);
+      }
+    },
+    [address, network, stacksNetwork]
+  );
+
+  return { placeOutcomeStake, isLoading, error, txId, reset };
+}

--- a/frontend/src/hooks/useMultiStake.ts
+++ b/frontend/src/hooks/useMultiStake.ts
@@ -4,7 +4,7 @@ import { uintCV, PostConditionMode, Pc } from '@stacks/transactions';
 import { stxToMicroStx, MIN_STAKE, MAX_STAKE } from '../constants';
 import { useWallet } from '../components/WalletProvider';
 import { useNetwork } from '../contexts/NetworkContext';
-import { CONTRACT_NAMES, getContractAddress } from '../config/contracts';
+import { MARKET_MULTI_CONTRACT } from '../config/contracts';
 import { validateAmount, validateMarketId } from '../utils/validation';
 
 interface UseMultiStakeReturn {
@@ -22,7 +22,7 @@ interface UseMultiStakeReturn {
 
 export function useMultiStake(): UseMultiStakeReturn {
   const { address } = useWallet();
-  const { stacksNetwork, network } = useNetwork();
+  const { stacksNetwork } = useNetwork();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [txId, setTxId] = useState<string | null>(null);
@@ -63,14 +63,12 @@ export function useMultiStake(): UseMultiStakeReturn {
 
       try {
         const stakeMicroStx = stxToMicroStx(amount);
-        const contractAddress = getContractAddress(CONTRACT_NAMES.MARKET_MULTI, network);
-
         const postConditions = [Pc.principal(address).willSendEq(stakeMicroStx).ustx()];
 
         await openContractCall({
           network: stacksNetwork,
-          contractAddress,
-          contractName: CONTRACT_NAMES.MARKET_MULTI,
+          contractAddress: MARKET_MULTI_CONTRACT.address,
+          contractName: MARKET_MULTI_CONTRACT.name,
           functionName: 'stake-on-outcome',
           functionArgs: [uintCV(marketId), uintCV(outcomeIndex), uintCV(stakeMicroStx)],
           postConditionMode: PostConditionMode.Deny,
@@ -90,7 +88,7 @@ export function useMultiStake(): UseMultiStakeReturn {
         setIsLoading(false);
       }
     },
-    [address, network, stacksNetwork]
+    [address, stacksNetwork]
   );
 
   return { placeOutcomeStake, isLoading, error, txId, reset };

--- a/frontend/src/pages/CreateMultiMarketPage.tsx
+++ b/frontend/src/pages/CreateMultiMarketPage.tsx
@@ -1,0 +1,157 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useMultiMarketCreation } from '../hooks/useMultiMarketCreation';
+
+function getCurrentBlockEstimate(): number {
+  return Math.floor(Date.now() / 600000);
+}
+
+export function CreateMultiMarketPage() {
+  const { createMultiMarket, state } = useMultiMarketCreation();
+  const [question, setQuestion] = useState('');
+  const [outcomes, setOutcomes] = useState(['', '', '']);
+  const [durationDays, setDurationDays] = useState(7);
+  const [resolutionDelayDays, setResolutionDelayDays] = useState(2);
+
+  const currentBlock = useMemo(() => getCurrentBlockEstimate(), []);
+  const endDate = useMemo(() => currentBlock + durationDays * 144, [currentBlock, durationDays]);
+  const resolutionDate = useMemo(
+    () => endDate + resolutionDelayDays * 144,
+    [endDate, resolutionDelayDays]
+  );
+
+  const canSubmit = useMemo(() => {
+    const trimmedQuestion = question.trim();
+    const validOutcomes = outcomes.map((value) => value.trim()).filter(Boolean);
+    return (
+      trimmedQuestion.length >= 10 &&
+      validOutcomes.length >= 3 &&
+      validOutcomes.length <= 10 &&
+      endDate < resolutionDate
+    );
+  }, [question, outcomes, endDate, resolutionDate]);
+
+  const updateOutcome = (index: number, value: string) => {
+    setOutcomes((prev) => prev.map((item, idx) => (idx === index ? value : item)));
+  };
+
+  const addOutcome = () => {
+    setOutcomes((prev) => (prev.length >= 10 ? prev : [...prev, '']));
+  };
+
+  const removeOutcome = (index: number) => {
+    setOutcomes((prev) => {
+      if (prev.length <= 3) return prev;
+      return prev.filter((_, idx) => idx !== index);
+    });
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const preparedOutcomes = outcomes.map((value) => value.trim()).filter(Boolean);
+    await createMultiMarket({
+      question: question.trim(),
+      outcomes: preparedOutcomes,
+      endDate,
+      resolutionDate,
+    });
+  };
+
+  return (
+    <div className="pt-[72px] min-h-screen bg-white dark:bg-black">
+      <div className="container max-w-4xl py-8 sm:py-12 lg:py-16 px-4 sm:px-6">
+        <div className="mb-8">
+          <Link to="/multi-markets" className="text-neutral-500 hover:text-black dark:hover:text-white">
+            Back to Multi Markets
+          </Link>
+          <h1 className="text-3xl font-bold text-black dark:text-white mt-4">Create Multi-Outcome Market</h1>
+          <p className="text-neutral-600 dark:text-neutral-400 mt-2">
+            Define a market with 3 to 10 outcomes and publish it on-chain.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="card p-4 sm:p-6 lg:p-8 space-y-6">
+          <div>
+            <label className="block text-sm font-semibold text-black dark:text-white mb-2" htmlFor="multi-question">
+              Market Question
+            </label>
+            <textarea
+              id="multi-question"
+              value={question}
+              onChange={(event) => setQuestion(event.target.value)}
+              className="input w-full min-h-[96px]"
+              placeholder="Who will win the 2026 World Cup?"
+              maxLength={256}
+            />
+          </div>
+
+          <div>
+            <div className="flex justify-between items-center mb-2">
+              <label className="block text-sm font-semibold text-black dark:text-white">Outcomes</label>
+              <button type="button" className="btn btn-secondary btn-sm" onClick={addOutcome}>
+                Add Outcome
+              </button>
+            </div>
+            <div className="space-y-3">
+              {outcomes.map((outcome, index) => (
+                <div key={`outcome-${index}`} className="flex gap-2">
+                  <input
+                    value={outcome}
+                    onChange={(event) => updateOutcome(index, event.target.value)}
+                    className="input w-full"
+                    placeholder={`Outcome ${index + 1}`}
+                    maxLength={100}
+                  />
+                  <button type="button" className="btn btn-secondary btn-sm" onClick={() => removeOutcome(index)}>
+                    Remove
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-semibold text-black dark:text-white mb-2">Market Duration (days)</label>
+              <input
+                type="number"
+                min={1}
+                max={180}
+                value={durationDays}
+                onChange={(event) => setDurationDays(Number(event.target.value))}
+                className="input w-full"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-semibold text-black dark:text-white mb-2">Resolution Delay (days)</label>
+              <input
+                type="number"
+                min={1}
+                max={30}
+                value={resolutionDelayDays}
+                onChange={(event) => setResolutionDelayDays(Number(event.target.value))}
+                className="input w-full"
+              />
+            </div>
+          </div>
+
+          <div className="text-sm text-neutral-500 dark:text-neutral-400">
+            End block: {endDate.toLocaleString()} | Resolution block: {resolutionDate.toLocaleString()}
+          </div>
+
+          {state.error && <p className="text-sm text-red-500">{state.error}</p>}
+          {state.success && (
+            <p className="text-sm text-emerald-500">
+              Multi-outcome market creation transaction submitted successfully.
+            </p>
+          )}
+          {state.txId && <p className="text-xs text-neutral-500 break-all">Transaction: {state.txId}</p>}
+
+          <button type="submit" className="btn btn-primary" disabled={!canSubmit || state.isCreating}>
+            {state.isCreating ? 'Creating Market...' : 'Create Multi-Outcome Market'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/CreateMultiMarketPage.tsx
+++ b/frontend/src/pages/CreateMultiMarketPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useMultiMarketCreation } from '../hooks/useMultiMarketCreation';
+import { validateMultiOutcomeInputs } from '../utils/validation';
 
 function getCurrentBlockEstimate(): number {
   return Math.floor(Date.now() / 600000);
@@ -19,17 +20,17 @@ export function CreateMultiMarketPage() {
     () => endDate + resolutionDelayDays * 144,
     [endDate, resolutionDelayDays]
   );
+  const inputValidation = useMemo(
+    () => validateMultiOutcomeInputs(question, outcomes),
+    [question, outcomes]
+  );
 
   const canSubmit = useMemo(() => {
-    const trimmedQuestion = question.trim();
-    const validOutcomes = outcomes.map((value) => value.trim()).filter(Boolean);
     return (
-      trimmedQuestion.length >= 10 &&
-      validOutcomes.length >= 3 &&
-      validOutcomes.length <= 10 &&
+      inputValidation.isValid &&
       endDate < resolutionDate
     );
-  }, [question, outcomes, endDate, resolutionDate]);
+  }, [inputValidation.isValid, endDate, resolutionDate]);
 
   const updateOutcome = (index: number, value: string) => {
     setOutcomes((prev) => prev.map((item, idx) => (idx === index ? value : item)));
@@ -138,6 +139,12 @@ export function CreateMultiMarketPage() {
           <div className="text-sm text-neutral-500 dark:text-neutral-400">
             End block: {endDate.toLocaleString()} | Resolution block: {resolutionDate.toLocaleString()}
           </div>
+
+          {!inputValidation.isValid && (
+            <p className="text-sm text-red-500">
+              {inputValidation.error}
+            </p>
+          )}
 
           {state.error && <p className="text-sm text-red-500">{state.error}</p>}
           {state.success && (

--- a/frontend/src/pages/CreateMultiMarketPage.tsx
+++ b/frontend/src/pages/CreateMultiMarketPage.tsx
@@ -28,9 +28,11 @@ export function CreateMultiMarketPage() {
   const canSubmit = useMemo(() => {
     return (
       inputValidation.isValid &&
+      durationDays >= 1 &&
+      resolutionDelayDays >= 1 &&
       endDate < resolutionDate
     );
-  }, [inputValidation.isValid, endDate, resolutionDate]);
+  }, [durationDays, resolutionDelayDays, inputValidation.isValid, endDate, resolutionDate]);
 
   const updateOutcome = (index: number, value: string) => {
     setOutcomes((prev) => prev.map((item, idx) => (idx === index ? value : item)));

--- a/frontend/src/pages/MarketsPage.tsx
+++ b/frontend/src/pages/MarketsPage.tsx
@@ -51,6 +51,26 @@ export function MarketsPage() {
             >
               <span>+</span> Create Market
             </Link>
+            <Link
+              to="/multi-markets"
+              style={{
+                marginLeft: 12,
+                padding: '12px 24px',
+                backgroundColor: '#111827',
+                border: '1px solid #374151',
+                borderRadius: '10px',
+                color: '#FFFFFF',
+                fontSize: '15px',
+                fontWeight: '600',
+                textDecoration: 'none',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '8px',
+                transition: 'all 0.2s',
+              }}
+            >
+              Multi Markets
+            </Link>
           </div>
           <p style={{ fontSize: 18, color: '#737373' }}>
             Browse and trade on prediction markets

--- a/frontend/src/pages/MultiMarketsPage.tsx
+++ b/frontend/src/pages/MultiMarketsPage.tsx
@@ -1,0 +1,102 @@
+import { Link } from 'react-router-dom';
+import { useMultiMarkets } from '../hooks/useMultiMarkets';
+import { formatAddress, formatStx } from '../utils/helpers';
+
+export function MultiMarketsPage() {
+  const { markets, isLoading, error, refetch } = useMultiMarkets();
+
+  return (
+    <div style={{ paddingTop: 72, minHeight: '100vh', background: '#000' }}>
+      <div style={{ maxWidth: 1200, margin: '0 auto', padding: '64px 24px' }}>
+        <div style={{ marginBottom: 32, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div>
+            <h1 style={{ fontSize: 36, fontWeight: 700, color: '#fff', margin: 0 }}>Multi-Outcome Markets</h1>
+            <p style={{ fontSize: 18, color: '#737373', marginTop: 12 }}>
+              Trade across markets with three or more outcomes.
+            </p>
+          </div>
+          <div style={{ display: 'flex', gap: 12 }}>
+            <button
+              onClick={refetch}
+              style={{
+                padding: '12px 20px',
+                background: '#1a1a1a',
+                border: '1px solid #333',
+                borderRadius: 10,
+                color: '#fff',
+                cursor: 'pointer',
+              }}
+            >
+              Refresh
+            </button>
+            <Link
+              to="/create-multi-market"
+              style={{
+                padding: '12px 20px',
+                background: '#2563EB',
+                borderRadius: 10,
+                color: '#fff',
+                textDecoration: 'none',
+                fontWeight: 600,
+              }}
+            >
+              Create Multi Market
+            </Link>
+          </div>
+        </div>
+
+        {isLoading && <p style={{ color: '#737373' }}>Loading markets...</p>}
+        {error && <p style={{ color: '#ef4444' }}>{error}</p>}
+
+        {!isLoading && !error && markets.length === 0 && (
+          <div style={{ color: '#9CA3AF', border: '1px solid #1F1F1F', borderRadius: 12, padding: 24 }}>
+            No multi-outcome markets available.
+          </div>
+        )}
+
+        <div style={{ display: 'grid', gap: 20 }}>
+          {markets.map((market) => {
+            const totalPool = market.outcomes.reduce((sum, outcome) => sum + outcome.stake, 0);
+            return (
+              <Link
+                key={market.id}
+                to={`/multi-trade/${market.id}`}
+                style={{
+                  display: 'block',
+                  textDecoration: 'none',
+                  border: '1px solid #1F1F1F',
+                  borderRadius: 16,
+                  padding: 24,
+                  background: '#0A0A0A',
+                }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 12 }}>
+                  <h3 style={{ fontSize: 22, fontWeight: 700, color: '#fff', margin: 0 }}>{market.question}</h3>
+                  <span style={{ color: '#9CA3AF', fontSize: 13 }}>#{market.id}</span>
+                </div>
+
+                <p style={{ color: '#9CA3AF', marginBottom: 16 }}>Creator: {formatAddress(market.creator)}</p>
+
+                <div style={{ display: 'grid', gap: 10, marginBottom: 16 }}>
+                  {market.outcomes.map((outcome) => (
+                    <div key={outcome.index}>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', color: '#D1D5DB', marginBottom: 4 }}>
+                        <span>{outcome.name}</span>
+                        <span>{outcome.percentage}%</span>
+                      </div>
+                      <div style={{ height: 8, background: '#1F2937', borderRadius: 999, overflow: 'hidden' }}>
+                        <div style={{ width: `${outcome.percentage}%`, height: '100%', background: '#3B82F6' }} />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                <p style={{ color: '#93C5FD', fontWeight: 600, margin: 0 }}>Total Pool: {formatStx(totalPool)}</p>
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/MultiMarketsPage.tsx
+++ b/frontend/src/pages/MultiMarketsPage.tsx
@@ -18,16 +18,18 @@ export function MultiMarketsPage() {
           <div style={{ display: 'flex', gap: 12 }}>
             <button
               onClick={refetch}
+              disabled={isLoading}
               style={{
                 padding: '12px 20px',
                 background: '#1a1a1a',
                 border: '1px solid #333',
                 borderRadius: 10,
                 color: '#fff',
-                cursor: 'pointer',
+                cursor: isLoading ? 'not-allowed' : 'pointer',
+                opacity: isLoading ? 0.7 : 1,
               }}
             >
-              Refresh
+              {isLoading ? 'Refreshing...' : 'Refresh'}
             </button>
             <Link
               to="/create-multi-market"

--- a/frontend/src/pages/MultiTradePage.tsx
+++ b/frontend/src/pages/MultiTradePage.tsx
@@ -32,10 +32,12 @@ export function MultiTradePage() {
     if (!market || selectedOutcome === null) return;
     if (!stakeValidation.isValid) return;
     const amount = Number(stakeAmount);
+    if (!Number.isFinite(amount)) return;
     setTradeSuccess(false);
     await placeOutcomeStake(market.id, selectedOutcome, amount, async () => {
       setTradeSuccess(true);
       setSelectedOutcome(null);
+      setStakeAmount('10');
       await refetch();
     });
   };

--- a/frontend/src/pages/MultiTradePage.tsx
+++ b/frontend/src/pages/MultiTradePage.tsx
@@ -1,0 +1,149 @@
+import { useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useMultiMarkets } from '../hooks/useMultiMarkets';
+import { useMultiStake } from '../hooks/useMultiStake';
+import { formatStx } from '../utils/helpers';
+import { validateAmount } from '../utils/validation';
+import { MIN_STAKE, MAX_STAKE } from '../constants';
+import { useWallet } from '../components/WalletProvider';
+
+export function MultiTradePage() {
+  const { id } = useParams<{ id: string }>();
+  const marketId = id ? Number(id) : NaN;
+  const { markets, isLoading, error, refetch } = useMultiMarkets();
+  const { placeOutcomeStake, isLoading: isStaking, error: stakeError, txId } = useMultiStake();
+  const { isConnected, connect } = useWallet();
+  const [selectedOutcome, setSelectedOutcome] = useState<number | null>(null);
+  const [stakeAmount, setStakeAmount] = useState('10');
+  const [tradeSuccess, setTradeSuccess] = useState(false);
+
+  const market = useMemo(() => markets.find((item) => item.id === marketId) || null, [markets, marketId]);
+  const totalPool = useMemo(
+    () => (market ? market.outcomes.reduce((sum, outcome) => sum + outcome.stake, 0) : 0),
+    [market]
+  );
+
+  const stakeValidation = useMemo(
+    () => validateAmount(stakeAmount, MIN_STAKE, MAX_STAKE),
+    [stakeAmount]
+  );
+
+  const handleStake = async () => {
+    if (!market || selectedOutcome === null) return;
+    if (!stakeValidation.isValid) return;
+    const amount = Number(stakeAmount);
+    setTradeSuccess(false);
+    await placeOutcomeStake(market.id, selectedOutcome, amount, async () => {
+      setTradeSuccess(true);
+      setSelectedOutcome(null);
+      await refetch();
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="pt-[72px] min-h-screen flex items-center justify-center">
+        <p className="text-neutral-500">Loading multi-outcome market...</p>
+      </div>
+    );
+  }
+
+  if (error || !market || Number.isNaN(marketId)) {
+    return (
+      <div className="pt-[72px] min-h-screen flex items-center justify-center px-4">
+        <div className="text-center">
+          <h2 className="text-2xl font-bold text-black dark:text-white mb-2">Market Not Found</h2>
+          <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+            {error || 'The selected multi-outcome market is not available.'}
+          </p>
+          <Link to="/multi-markets" className="btn btn-primary">
+            Back to Multi Markets
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pt-[72px] min-h-screen bg-white dark:bg-black">
+      <div className="container max-w-5xl py-8 sm:py-12 lg:py-16 px-4 sm:px-6">
+        <Link to="/multi-markets" className="inline-flex items-center gap-2 text-neutral-500 hover:text-black dark:hover:text-white mb-8">
+          Back to Multi Markets
+        </Link>
+
+        <div className="space-y-8">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-black dark:text-white mb-2">{market.question}</h1>
+            <p className="text-neutral-600 dark:text-neutral-400">Total Pool: {formatStx(totalPool)}</p>
+          </div>
+
+          <div className="card p-4 sm:p-6 lg:p-8 space-y-4">
+            {market.outcomes.map((outcome) => (
+              <button
+                key={outcome.index}
+                type="button"
+                onClick={() => setSelectedOutcome(outcome.index)}
+                className={`w-full text-left rounded-xl border p-4 transition-colors ${
+                  selectedOutcome === outcome.index
+                    ? 'border-blue-500 bg-blue-500/10'
+                    : 'border-neutral-300 dark:border-neutral-800 hover:border-neutral-400 dark:hover:border-neutral-700'
+                }`}
+              >
+                <div className="flex justify-between items-center mb-2">
+                  <span className="font-semibold text-black dark:text-white">{outcome.name}</span>
+                  <span className="text-blue-600 dark:text-blue-400 font-semibold">{outcome.percentage}%</span>
+                </div>
+                <div className="h-2 bg-neutral-200 dark:bg-neutral-800 rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-blue-500"
+                    style={{ width: `${outcome.percentage}%` }}
+                  />
+                </div>
+                <p className="text-xs text-neutral-500 mt-2">{formatStx(outcome.stake)} staked</p>
+              </button>
+            ))}
+          </div>
+
+          <div className="card p-4 sm:p-6 lg:p-8 space-y-4">
+            <h3 className="text-lg font-semibold text-black dark:text-white">Place Stake</h3>
+            {!isConnected ? (
+              <button type="button" className="btn btn-primary" onClick={() => connect()}>
+                Connect Wallet
+              </button>
+            ) : (
+              <>
+                <input
+                  type="number"
+                  min={MIN_STAKE}
+                  max={MAX_STAKE}
+                  value={stakeAmount}
+                  onChange={(e) => setStakeAmount(e.target.value)}
+                  className="input w-full"
+                />
+                {!stakeValidation.isValid && (
+                  <p className="text-sm text-red-500">{stakeValidation.error}</p>
+                )}
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  disabled={selectedOutcome === null || !stakeValidation.isValid || isStaking}
+                  onClick={handleStake}
+                >
+                  {isStaking ? 'Submitting...' : 'Stake on Selected Outcome'}
+                </button>
+              </>
+            )}
+
+            {stakeError && <p className="text-sm text-red-500">{stakeError}</p>}
+            {tradeSuccess && <p className="text-sm text-emerald-500">Stake submitted successfully.</p>}
+            {txId && (
+              <p className="text-xs text-neutral-500 break-all">
+                Transaction: {txId}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/market.ts
+++ b/frontend/src/types/market.ts
@@ -36,6 +36,30 @@ export interface Position {
   claimed: boolean;
 }
 
+export interface MultiOutcomeOption {
+  index: number;
+  name: string;
+  stake: number;
+  percentage: number;
+}
+
+export interface MultiMarket {
+  id: number;
+  question: string;
+  creator: string;
+  outcomes: MultiOutcomeOption[];
+  outcomeCount: number;
+  endDate: number;
+  resolutionDate: number;
+  status: number;
+  winningOutcome: number | null;
+  createdAt: number;
+}
+
+export function isMultiMarket(market: Market | MultiMarket): market is MultiMarket {
+  return 'outcomes' in market;
+}
+
 export interface TransactionStatus {
   pending: boolean;
   success: boolean;
@@ -138,4 +162,3 @@ export const CATEGORY_METADATA: Record<MarketCategory, CategoryMetadata> = {
     icon: '🔮',
   },
 };
-

--- a/frontend/src/utils/__tests__/helpers.test.ts
+++ b/frontend/src/utils/__tests__/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   getOutcomeLabel,
 } from '../helpers';
 import { MarketStatus, MarketOutcome } from '../../types/market';
+import { isMultiMarket } from '../../types/market';
 
 describe('parseMarketData', () => {
   it('parses valid market data correctly', () => {
@@ -259,5 +260,41 @@ describe('getOutcomeLabel', () => {
     expect(getOutcomeLabel(0 as MarketOutcome)).toBe('Pending');
     expect(getOutcomeLabel(1 as MarketOutcome)).toBe('Yes');
     expect(getOutcomeLabel(2 as MarketOutcome)).toBe('No');
+  });
+});
+
+describe('isMultiMarket', () => {
+  it('returns false for binary market shape', () => {
+    const market = {
+      id: 1,
+      question: 'Will it rain?',
+      creator: 'SP123',
+      endDate: 100,
+      resolutionDate: 110,
+      totalYesStake: 10,
+      totalNoStake: 20,
+      status: MarketStatus.ACTIVE,
+      outcome: MarketOutcome.NONE,
+      createdAt: 90,
+    };
+
+    expect(isMultiMarket(market)).toBe(false);
+  });
+
+  it('returns true for multi market shape', () => {
+    const market = {
+      id: 2,
+      question: 'Who wins?',
+      creator: 'SP123',
+      outcomes: [{ index: 0, name: 'A', stake: 100, percentage: 100 }],
+      outcomeCount: 1,
+      endDate: 100,
+      resolutionDate: 110,
+      status: 0,
+      winningOutcome: null,
+      createdAt: 90,
+    };
+
+    expect(isMultiMarket(market as any)).toBe(true);
   });
 });

--- a/frontend/src/utils/__tests__/multiMarket.test.ts
+++ b/frontend/src/utils/__tests__/multiMarket.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { basisPointsToPercent, microStxToStxValue, parseMultiMarketData } from '../multiMarket';
+
+describe('parseMultiMarketData', () => {
+  it('parses market payload and computes outcome percentages', () => {
+    const rawData = {
+      question: 'Who will win?',
+      creator: 'SP123',
+      'outcome-names': ['A', 'B', 'C'],
+      'outcome-stakes': ['5000000', '3000000', '2000000'],
+      'outcome-count': '3',
+      'end-date': '100',
+      'resolution-date': '120',
+      status: '0',
+      'winning-outcome': null,
+      'created-at': '90',
+    };
+
+    const parsed = parseMultiMarketData(1, rawData);
+
+    expect(parsed.id).toBe(1);
+    expect(parsed.outcomeCount).toBe(3);
+    expect(parsed.outcomes[0].name).toBe('A');
+    expect(parsed.outcomes[0].percentage).toBe(50);
+    expect(parsed.outcomes[1].percentage).toBe(30);
+    expect(parsed.outcomes[2].percentage).toBe(20);
+  });
+
+  it('handles missing outcome names with fallback labels', () => {
+    const rawData = {
+      question: 'Market',
+      creator: 'SP123',
+      'outcome-names': ['A'],
+      'outcome-stakes': ['100', '200', '300'],
+      'outcome-count': 3,
+      'end-date': 100,
+      'resolution-date': 120,
+      status: 0,
+      'winning-outcome': null,
+      'created-at': 90,
+    };
+
+    const parsed = parseMultiMarketData(2, rawData);
+
+    expect(parsed.outcomes[1].name).toBe('Outcome 2');
+    expect(parsed.outcomes[2].name).toBe('Outcome 3');
+  });
+});
+
+describe('basisPointsToPercent', () => {
+  it('converts basis points to percentage', () => {
+    expect(basisPointsToPercent(6000)).toBe(60);
+    expect(basisPointsToPercent(3333)).toBe(33.3);
+  });
+});
+
+describe('microStxToStxValue', () => {
+  it('converts micro STX to STX value', () => {
+    expect(microStxToStxValue(1500000)).toBe(1.5);
+  });
+});

--- a/frontend/src/utils/__tests__/validation.test.ts
+++ b/frontend/src/utils/__tests__/validation.test.ts
@@ -6,6 +6,7 @@ import {
   validateMemo,
   validateMarketId,
   validateUrl,
+  validateMultiOutcomeInputs,
   sanitizeInput,
   sanitizeHtml,
   VALIDATION_LIMITS,
@@ -148,6 +149,41 @@ describe('validateMarketQuestion', () => {
   it('handles whitespace correctly', () => {
     const result = validateMarketQuestion('   Will this happen today?   ');
     expect(result.isValid).toBe(true);
+  });
+});
+
+describe('validateMultiOutcomeInputs', () => {
+  it('accepts valid question and outcomes', () => {
+    const result = validateMultiOutcomeInputs('Who will win the final match?', ['A', 'B', 'C']);
+    expect(result.isValid).toBe(true);
+  });
+
+  it('rejects fewer than minimum outcomes', () => {
+    const result = validateMultiOutcomeInputs('Who will win the final match?', ['A', 'B']);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain(`${VALIDATION_LIMITS.MIN_MULTI_OUTCOMES}`);
+  });
+
+  it('rejects more than maximum outcomes', () => {
+    const result = validateMultiOutcomeInputs(
+      'Who will win the final match?',
+      ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K']
+    );
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain(`${VALIDATION_LIMITS.MAX_MULTI_OUTCOMES}`);
+  });
+
+  it('rejects duplicate outcomes', () => {
+    const result = validateMultiOutcomeInputs('Who will win the final match?', ['A', 'B', 'a']);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBe('Outcomes must be unique');
+  });
+
+  it('rejects overly long outcomes', () => {
+    const long = 'X'.repeat(VALIDATION_LIMITS.MAX_OUTCOME_LABEL_LENGTH + 1);
+    const result = validateMultiOutcomeInputs('Who will win the final match?', ['A', 'B', long]);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain(`${VALIDATION_LIMITS.MAX_OUTCOME_LABEL_LENGTH}`);
   });
 });
 

--- a/frontend/src/utils/multiMarket.ts
+++ b/frontend/src/utils/multiMarket.ts
@@ -1,0 +1,88 @@
+import type { MultiMarket, MultiOutcomeOption } from '../types/market';
+
+const BASIS_POINTS_DIVISOR = 10000;
+const MICROSTX_PER_STX = 1_000_000;
+
+function parseOutcomeName(raw: unknown): string {
+  if (typeof raw === 'string') {
+    return raw;
+  }
+  if (raw && typeof raw === 'object' && 'value' in raw) {
+    const value = (raw as { value: unknown }).value;
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+  return '';
+}
+
+function parseOutcomeStake(raw: unknown): number {
+  if (typeof raw === 'number') {
+    return raw;
+  }
+  if (typeof raw === 'string') {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  if (raw && typeof raw === 'object' && 'value' in raw) {
+    const value = (raw as { value: unknown }).value;
+    if (typeof value === 'number') {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : 0;
+    }
+  }
+  return 0;
+}
+
+export function parseMultiMarketData(marketId: number, rawData: any): MultiMarket {
+  const namesRaw = rawData['outcome-names'] ?? [];
+  const stakesRaw = rawData['outcome-stakes'] ?? [];
+  const outcomeCount = Number(rawData['outcome-count'] ?? 0);
+
+  const stakes: number[] = Array.isArray(stakesRaw)
+    ? stakesRaw.map((value) => parseOutcomeStake(value))
+    : [];
+  const names: string[] = Array.isArray(namesRaw)
+    ? namesRaw.map((value) => parseOutcomeName(value))
+    : [];
+
+  const totalPool = stakes.reduce((sum, stake) => sum + stake, 0);
+
+  const outcomes: MultiOutcomeOption[] = Array.from({ length: outcomeCount }, (_, index) => {
+    const stake = stakes[index] ?? 0;
+    const percentage = totalPool > 0 ? Math.round((stake / totalPool) * 1000) / 10 : 0;
+    return {
+      index,
+      name: names[index] || `Outcome ${index + 1}`,
+      stake,
+      percentage,
+    };
+  });
+
+  return {
+    id: marketId,
+    question: rawData.question,
+    creator: rawData.creator,
+    outcomes,
+    outcomeCount,
+    endDate: Number(rawData['end-date']),
+    resolutionDate: Number(rawData['resolution-date']),
+    status: Number(rawData.status),
+    winningOutcome:
+      rawData['winning-outcome'] && typeof rawData['winning-outcome'] === 'object' && 'value' in rawData['winning-outcome']
+        ? Number(rawData['winning-outcome'].value)
+        : null,
+    createdAt: Number(rawData['created-at']),
+  };
+}
+
+export function basisPointsToPercent(basisPoints: number): number {
+  return Math.round((basisPoints / BASIS_POINTS_DIVISOR) * 1000) / 10;
+}
+
+export function microStxToStxValue(microStx: number): number {
+  return microStx / MICROSTX_PER_STX;
+}

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -18,6 +18,9 @@ export const VALIDATION_LIMITS = {
   MAX_MARKET_QUESTION_LENGTH: 500,
   STACKS_ADDRESS_LENGTH: 41,
   MEMO_MAX_LENGTH: 34,
+  MIN_MULTI_OUTCOMES: 3,
+  MAX_MULTI_OUTCOMES: 10,
+  MAX_OUTCOME_LABEL_LENGTH: 100,
 } as const;
 
 /**
@@ -106,6 +109,49 @@ export function validateMarketQuestion(question: string): ValidationResult {
   const wordCount = trimmedQuestion.split(/\s+/).filter(word => word.length > 0).length;
   if (wordCount < 3) {
     return { isValid: false, error: 'Question must contain at least 3 words' };
+  }
+
+  return { isValid: true };
+}
+
+export function validateMultiOutcomeInputs(
+  question: string,
+  outcomes: string[]
+): ValidationResult {
+  const questionValidation = validateMarketQuestion(question);
+  if (!questionValidation.isValid) {
+    return questionValidation;
+  }
+
+  const normalizedOutcomes = outcomes.map((value) => value.trim()).filter(Boolean);
+
+  if (normalizedOutcomes.length < VALIDATION_LIMITS.MIN_MULTI_OUTCOMES) {
+    return {
+      isValid: false,
+      error: `At least ${VALIDATION_LIMITS.MIN_MULTI_OUTCOMES} outcomes are required`,
+    };
+  }
+
+  if (normalizedOutcomes.length > VALIDATION_LIMITS.MAX_MULTI_OUTCOMES) {
+    return {
+      isValid: false,
+      error: `Maximum ${VALIDATION_LIMITS.MAX_MULTI_OUTCOMES} outcomes are allowed`,
+    };
+  }
+
+  const tooLongOutcome = normalizedOutcomes.find(
+    (value) => value.length > VALIDATION_LIMITS.MAX_OUTCOME_LABEL_LENGTH
+  );
+  if (tooLongOutcome) {
+    return {
+      isValid: false,
+      error: `Outcome labels must be ${VALIDATION_LIMITS.MAX_OUTCOME_LABEL_LENGTH} characters or less`,
+    };
+  }
+
+  const normalizedKeys = normalizedOutcomes.map((value) => value.toLowerCase());
+  if (new Set(normalizedKeys).size !== normalizedKeys.length) {
+    return { isValid: false, error: 'Outcomes must be unique' };
   }
 
   return { isValid: true };
@@ -222,6 +268,7 @@ export default {
   validateAmount,
   validateStacksAddress,
   validateMarketQuestion,
+  validateMultiOutcomeInputs,
   validateMemo,
   validateMarketId,
   validateUrl,


### PR DESCRIPTION
## Summary
This PR introduces additive multi-outcome market support in the frontend while preserving existing binary market behavior.

## What changed
- Added multi-outcome market types and guard
- Added multi-market parsing helpers
- Added hooks for listing, creating, and staking multi-outcome markets
- Added pages for multi-outcome listing, trading, and creation
- Wired routes and navigation entry points
- Added validation for multi-outcome market inputs
- Added focused unit test coverage for new utilities and validation

## Validation
- Frontend build passes
- Focused utility tests pass

## Notes
- Existing binary market flows remain intact
- Feature is implemented as an additive path