### PR TITLE
Implement realtime market updates across market pages

### DIFF
--- a/frontend/src/hooks/__tests__/useRealtimeSignal.test.ts
+++ b/frontend/src/hooks/__tests__/useRealtimeSignal.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRealtimeSignal } from '../useRealtimeSignal';
+
+vi.mock('../useApi', () => ({
+  useApi: () => ({
+    baseUrl: 'https://api.mainnet.hiro.so',
+  }),
+}));
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  constructor() {
+    MockWebSocket.instances.push(this);
+  }
+
+  close() {
+    if (this.onclose) this.onclose();
+  }
+}
+
+describe('useRealtimeSignal', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.instances = [];
+    // @ts-expect-error test mock assignment
+    global.WebSocket = MockWebSocket;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('uses polling fallback when websocket is not open', () => {
+    const { result } = renderHook(() => useRealtimeSignal({ fallbackIntervalMs: 5000, reconnectIntervalMs: 2000 }));
+    const socket = MockWebSocket.instances[0];
+
+    act(() => {
+      socket.onerror?.();
+    });
+
+    expect(result.current.source).toBe('poll');
+    expect(result.current.isSocketConnected).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current.signal).toBeGreaterThan(0);
+  });
+
+  it('switches to socket source when websocket opens', () => {
+    const { result } = renderHook(() => useRealtimeSignal());
+    const socket = MockWebSocket.instances[0];
+
+    expect(socket).toBeDefined();
+    act(() => {
+      socket.onopen?.();
+    });
+
+    expect(result.current.isSocketConnected).toBe(true);
+    expect(result.current.source).toBe('socket');
+  });
+});

--- a/frontend/src/hooks/useRealtimeSignal.ts
+++ b/frontend/src/hooks/useRealtimeSignal.ts
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from 'react';
+import { useApi } from './useApi';
+import { getRealtimeWsUrl } from '../utils/realtime';
+
+interface UseRealtimeSignalOptions {
+  enabled?: boolean;
+  reconnectIntervalMs?: number;
+  fallbackIntervalMs?: number;
+}
+
+interface UseRealtimeSignalResult {
+  signal: number;
+  isSocketConnected: boolean;
+  source: 'socket' | 'poll';
+}
+
+export function useRealtimeSignal(options: UseRealtimeSignalOptions = {}): UseRealtimeSignalResult {
+  const {
+    enabled = true,
+    reconnectIntervalMs = 10000,
+    fallbackIntervalMs = 30000,
+  } = options;
+
+  const [signal, setSignal] = useState(0);
+  const [isSocketConnected, setIsSocketConnected] = useState(false);
+  const { baseUrl } = useApi();
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<number | null>(null);
+  const pollTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    let mounted = true;
+    const wsUrl = getRealtimeWsUrl(baseUrl);
+
+    const tick = () => {
+      if (!mounted) return;
+      setSignal((prev) => prev + 1);
+    };
+
+    const clearTimers = () => {
+      if (reconnectTimerRef.current !== null) {
+        window.clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+      if (pollTimerRef.current !== null) {
+        window.clearInterval(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+
+    const startFallbackPolling = () => {
+      if (pollTimerRef.current !== null) return;
+      pollTimerRef.current = window.setInterval(tick, fallbackIntervalMs);
+    };
+
+    const stopFallbackPolling = () => {
+      if (pollTimerRef.current !== null) {
+        window.clearInterval(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+
+    const connect = () => {
+      try {
+        const ws = new WebSocket(wsUrl);
+        wsRef.current = ws;
+
+        ws.onopen = () => {
+          if (!mounted) return;
+          setIsSocketConnected(true);
+          stopFallbackPolling();
+        };
+
+        ws.onmessage = () => {
+          tick();
+        };
+
+        ws.onerror = () => {
+          if (!mounted) return;
+          setIsSocketConnected(false);
+          startFallbackPolling();
+        };
+
+        ws.onclose = () => {
+          if (!mounted) return;
+          setIsSocketConnected(false);
+          startFallbackPolling();
+          reconnectTimerRef.current = window.setTimeout(connect, reconnectIntervalMs);
+        };
+      } catch {
+        if (!mounted) return;
+        setIsSocketConnected(false);
+        startFallbackPolling();
+        reconnectTimerRef.current = window.setTimeout(connect, reconnectIntervalMs);
+      }
+    };
+
+    startFallbackPolling();
+    connect();
+
+    return () => {
+      mounted = false;
+      clearTimers();
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+  }, [baseUrl, enabled, fallbackIntervalMs, reconnectIntervalMs]);
+
+  return {
+    signal,
+    isSocketConnected,
+    source: isSocketConnected ? 'socket' : 'poll',
+  };
+}

--- a/frontend/src/pages/MarketsPage.tsx
+++ b/frontend/src/pages/MarketsPage.tsx
@@ -1,12 +1,16 @@
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useMarkets } from '../hooks/useMarkets';
 import { useMarketFiltering } from '../hooks/useMarketFiltering';
+import { useRealtimeSignal } from '../hooks/useRealtimeSignal';
 import { MarketCard } from '../components/MarketCard';
 import { MarketFilter } from '../components/MarketFilter';
 import { getCategoryConfig, CATEGORIES, MarketCategory } from '../utils/marketCategories';
 
 export function MarketsPage() {
   const { markets, isLoading, error, refetch } = useMarkets();
+  const { signal, source, isSocketConnected } = useRealtimeSignal({ enabled: true });
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<Date>(new Date());
   const {
     filteredMarkets,
     category,
@@ -22,6 +26,14 @@ export function MarketsPage() {
   } = useMarketFiltering({ markets, syncWithUrl: true });
 
   const activeCategory = getCategoryConfig(category);
+
+  useEffect(() => {
+    if (signal === 0) {
+      return;
+    }
+    refetch();
+    setLastUpdatedAt(new Date());
+  }, [signal, refetch]);
 
   return (
     <div style={{ paddingTop: 72, minHeight: '100vh', background: '#000' }}>
@@ -74,6 +86,9 @@ export function MarketsPage() {
           </div>
           <p style={{ fontSize: 18, color: '#737373' }}>
             Browse and trade on prediction markets
+          </p>
+          <p style={{ fontSize: 13, color: '#6B7280', marginTop: 8 }}>
+            Live updates: {isSocketConnected ? 'Connected' : 'Polling'} via {source} • Last update {lastUpdatedAt.toLocaleTimeString()}
           </p>
         </div>
 

--- a/frontend/src/pages/MultiMarketsPage.tsx
+++ b/frontend/src/pages/MultiMarketsPage.tsx
@@ -1,20 +1,35 @@
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useMultiMarkets } from '../hooks/useMultiMarkets';
+import { useRealtimeSignal } from '../hooks/useRealtimeSignal';
 import { formatAddress, formatStx } from '../utils/helpers';
 
 export function MultiMarketsPage() {
   const { markets, isLoading, error, refetch } = useMultiMarkets();
+  const { signal, source, isSocketConnected } = useRealtimeSignal({ enabled: true });
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<Date>(new Date());
+
+  useEffect(() => {
+    if (signal === 0) {
+      return;
+    }
+    refetch();
+    setLastUpdatedAt(new Date());
+  }, [signal, refetch]);
 
   return (
     <div style={{ paddingTop: 72, minHeight: '100vh', background: '#000' }}>
       <div style={{ maxWidth: 1200, margin: '0 auto', padding: '64px 24px' }}>
         <div style={{ marginBottom: 32, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <div>
-            <h1 style={{ fontSize: 36, fontWeight: 700, color: '#fff', margin: 0 }}>Multi-Outcome Markets</h1>
-            <p style={{ fontSize: 18, color: '#737373', marginTop: 12 }}>
-              Trade across markets with three or more outcomes.
-            </p>
-          </div>
+              <h1 style={{ fontSize: 36, fontWeight: 700, color: '#fff', margin: 0 }}>Multi-Outcome Markets</h1>
+              <p style={{ fontSize: 18, color: '#737373', marginTop: 12 }}>
+                Trade across markets with three or more outcomes.
+              </p>
+              <p style={{ fontSize: 13, color: '#6B7280', marginTop: 8 }}>
+                Live updates: {isSocketConnected ? 'Connected' : 'Polling'} via {source} • Last update {lastUpdatedAt.toLocaleTimeString()}
+              </p>
+            </div>
           <div style={{ display: 'flex', gap: 12 }}>
             <button
               onClick={refetch}

--- a/frontend/src/pages/MultiTradePage.tsx
+++ b/frontend/src/pages/MultiTradePage.tsx
@@ -1,7 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useMultiMarkets } from '../hooks/useMultiMarkets';
 import { useMultiStake } from '../hooks/useMultiStake';
+import { useRealtimeSignal } from '../hooks/useRealtimeSignal';
 import { formatStx } from '../utils/helpers';
 import { validateAmount } from '../utils/validation';
 import { MIN_STAKE, MAX_STAKE } from '../constants';
@@ -12,6 +13,7 @@ export function MultiTradePage() {
   const marketId = id ? Number(id) : NaN;
   const { markets, isLoading, error, refetch } = useMultiMarkets();
   const { placeOutcomeStake, isLoading: isStaking, error: stakeError, txId } = useMultiStake();
+  const { signal, source, isSocketConnected } = useRealtimeSignal({ enabled: true });
   const { isConnected, connect } = useWallet();
   const [selectedOutcome, setSelectedOutcome] = useState<number | null>(null);
   const [stakeAmount, setStakeAmount] = useState('10');
@@ -27,6 +29,13 @@ export function MultiTradePage() {
     () => validateAmount(stakeAmount, MIN_STAKE, MAX_STAKE),
     [stakeAmount]
   );
+
+  useEffect(() => {
+    if (signal === 0) {
+      return;
+    }
+    refetch();
+  }, [signal, refetch]);
 
   const handleStake = async () => {
     if (!market || selectedOutcome === null) return;
@@ -77,6 +86,9 @@ export function MultiTradePage() {
           <div>
             <h1 className="text-2xl sm:text-3xl font-bold text-black dark:text-white mb-2">{market.question}</h1>
             <p className="text-neutral-600 dark:text-neutral-400">Total Pool: {formatStx(totalPool)}</p>
+            <p className="text-xs text-neutral-500 mt-1">
+              Live: {isSocketConnected ? 'Connected' : 'Polling'} ({source})
+            </p>
           </div>
 
           <div className="card p-4 sm:p-6 lg:p-8 space-y-4">

--- a/frontend/src/pages/TradePage.tsx
+++ b/frontend/src/pages/TradePage.tsx
@@ -8,6 +8,7 @@ import { parseMarketData, calculateOdds, formatStx, getStatusLabel, formatAddres
 import { CONTRACT_ADDRESS, CONTRACT_NAME, MIN_STAKE, MAX_STAKE } from '../constants';
 import { useWallet } from '../components/WalletProvider';
 import { useStake } from '../hooks/useStake';
+import { useRealtimeSignal } from '../hooks/useRealtimeSignal';
 import { validateAmount, validateMarketId } from '../utils/validation';
 import { SocialButtons } from '../components/SocialButtons';
 
@@ -33,6 +34,7 @@ export function TradePage() {
   
   const { isConnected, connect } = useWallet();
   const { placeYesStake, placeNoStake, isLoading: isStaking, error: stakeError, txId } = useStake();
+  const { signal, source, isSocketConnected } = useRealtimeSignal({ enabled: true });
   
   const [market, setMarket] = useState<Market | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -84,6 +86,11 @@ export function TradePage() {
   useEffect(() => {
     fetchMarket();
   }, [fetchMarket]);
+
+  useEffect(() => {
+    if (signal === 0) return;
+    fetchMarket();
+  }, [signal, fetchMarket]);
 
   // Clear success messages when starting new trade or changing selection
   const resetTradeState = useCallback(() => {
@@ -195,6 +202,9 @@ export function TradePage() {
                 {getStatusLabel(market.status)}
               </span>
               <span className="text-sm text-neutral-500 font-mono">#{market.id}</span>
+              <span className="text-xs text-neutral-500">
+                Live: {isSocketConnected ? 'Connected' : 'Polling'} ({source})
+              </span>
             </div>
 
             <h1 className="text-xl sm:text-2xl lg:text-3xl font-bold text-white leading-tight">

--- a/frontend/src/utils/__tests__/realtime.test.ts
+++ b/frontend/src/utils/__tests__/realtime.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { getRealtimeWsUrl } from '../realtime';
+
+describe('getRealtimeWsUrl', () => {
+  it('converts https base URL to wss websocket URL', () => {
+    expect(getRealtimeWsUrl('https://api.mainnet.hiro.so')).toBe('wss://api.mainnet.hiro.so/extended/v1/ws');
+  });
+
+  it('converts http base URL to ws websocket URL', () => {
+    expect(getRealtimeWsUrl('http://localhost:3999')).toBe('ws://localhost:3999/extended/v1/ws');
+  });
+
+  it('handles base URL with trailing slash', () => {
+    expect(getRealtimeWsUrl('https://api.testnet.hiro.so/')).toBe('wss://api.testnet.hiro.so/extended/v1/ws');
+  });
+});

--- a/frontend/src/utils/realtime.ts
+++ b/frontend/src/utils/realtime.ts
@@ -1,0 +1,13 @@
+export function getRealtimeWsUrl(apiBaseUrl: string): string {
+  const base = apiBaseUrl.endsWith('/') ? apiBaseUrl.slice(0, -1) : apiBaseUrl;
+
+  if (base.startsWith('https://')) {
+    return `${base.replace('https://', 'wss://')}/extended/v1/ws`;
+  }
+
+  if (base.startsWith('http://')) {
+    return `${base.replace('http://', 'ws://')}/extended/v1/ws`;
+  }
+
+  return `${base}/extended/v1/ws`;
+}


### PR DESCRIPTION
## Summary\n- add a realtime signal layer with websocket-first updates and polling fallback\n- wire live refresh into markets, multi-markets, trade, and multi-trade pages\n- add focused tests for websocket URL generation and realtime hook behavior\n\n## Validation\n- cd frontend && npm run test:run\n- cd frontend && npm run build\n\nCloses #6