### PR TITLE
Enhance analytics dashboard with deterministic health and predictive insights

### DIFF
--- a/frontend/src/hooks/useAnalytics.ts
+++ b/frontend/src/hooks/useAnalytics.ts
@@ -17,62 +17,14 @@ import type {
   PersonalStats,
   TimeRange,
 } from '../types/analytics';
-import { CATEGORY_COLORS } from '../types/analytics';
-
-// Mock data generator for demo purposes
-// In production, this would fetch from blockchain/API
-function generateMockVolumeData(days: number): VolumeDataPoint[] {
-  const data: VolumeDataPoint[] = [];
-  const now = Date.now();
-  const dayMs = 24 * 60 * 60 * 1000;
-  
-  for (let i = days - 1; i >= 0; i--) {
-    const date = new Date(now - i * dayMs);
-    const baseVolume = 5000 + Math.random() * 10000;
-    const volume = Math.floor(baseVolume * (1 + Math.sin(i / 3) * 0.3));
-    
-    data.push({
-      date: date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-      timestamp: date.getTime(),
-      volume,
-      volumeFormatted: volume.toLocaleString(),
-      transactions: Math.floor(volume / 100),
-    });
-  }
-  
-  return data;
-}
-
-function generateMockActivityData(days: number): UserActivityData[] {
-  const data: UserActivityData[] = [];
-  const now = Date.now();
-  const dayMs = 24 * 60 * 60 * 1000;
-  
-  for (let i = days - 1; i >= 0; i--) {
-    const date = new Date(now - i * dayMs);
-    const baseUsers = 50 + Math.random() * 100;
-    
-    data.push({
-      date: date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-      activeUsers: Math.floor(baseUsers),
-      newUsers: Math.floor(baseUsers * 0.1),
-      transactions: Math.floor(baseUsers * 2),
-    });
-  }
-  
-  return data;
-}
-
-function getDaysFromTimeRange(range: TimeRange): number {
-  switch (range) {
-    case '24h': return 1;
-    case '7d': return 7;
-    case '30d': return 30;
-    case '90d': return 90;
-    case 'all': return 365;
-    default: return 30;
-  }
-}
+import {
+  buildCategoryDistribution,
+  buildMarketHealth,
+  buildPredictiveInsights,
+  buildUserActivity,
+  buildVolumeHistory,
+  getDaysFromTimeRange,
+} from '../utils/analytics';
 
 export function useAnalytics(initialTimeRange: TimeRange = '30d') {
   const { markets, isLoading: marketsLoading } = useMarkets();
@@ -153,54 +105,21 @@ export function useAnalytics(initialTimeRange: TimeRange = '30d') {
   }, [markets]);
 
   // Generate category distribution
-  const categoryDistribution = useMemo<CategoryData[]>(() => {
-    // Categorize markets by keywords in questions
-    const categories: Record<string, number> = {};
-    
-    markets.forEach(market => {
-      const q = market.question.toLowerCase();
-      let category = 'Other';
-      
-      if (q.includes('btc') || q.includes('bitcoin') || q.includes('eth') || q.includes('crypto')) {
-        category = 'Crypto';
-      } else if (q.includes('election') || q.includes('president') || q.includes('vote')) {
-        category = 'Politics';
-      } else if (q.includes('game') || q.includes('match') || q.includes('win') || q.includes('championship')) {
-        category = 'Sports';
-      } else if (q.includes('movie') || q.includes('oscar') || q.includes('award')) {
-        category = 'Entertainment';
-      } else if (q.includes('ai') || q.includes('tech') || q.includes('launch')) {
-        category = 'Technology';
-      } else if (q.includes('stock') || q.includes('market') || q.includes('price')) {
-        category = 'Finance';
-      }
-      
-      categories[category] = (categories[category] || 0) + 1;
-    });
-    
-    const total = Object.values(categories).reduce((a, b) => a + b, 0);
-    
-    return Object.entries(categories)
-      .map(([name, count]) => ({
-        name,
-        value: total > 0 ? (count / total) * 100 : 0,
-        count,
-        color: CATEGORY_COLORS[name] || CATEGORY_COLORS.Other,
-      }))
-      .sort((a, b) => b.value - a.value);
-  }, [markets]);
+  const categoryDistribution = useMemo<CategoryData[]>(() => buildCategoryDistribution(markets), [markets]);
 
-  // Volume history (mock data for now)
+  // Volume history derived from market creation and pool activity
   const volumeHistory = useMemo<VolumeDataPoint[]>(() => {
     const days = getDaysFromTimeRange(timeRange);
-    return generateMockVolumeData(days);
-  }, [timeRange]);
+    return buildVolumeHistory(markets, days);
+  }, [markets, timeRange]);
 
-  // User activity (mock data for now)
+  // User activity inferred from transaction counts
   const userActivity = useMemo<UserActivityData[]>(() => {
-    const days = getDaysFromTimeRange(timeRange);
-    return generateMockActivityData(Math.min(days, 30));
-  }, [timeRange]);
+    return buildUserActivity(volumeHistory);
+  }, [volumeHistory]);
+
+  const marketHealth = useMemo(() => buildMarketHealth(markets), [markets]);
+  const predictiveInsights = useMemo(() => buildPredictiveInsights(markets), [markets]);
 
   // Personal stats (mock for now)
   const personalStats = useMemo<PersonalStats | null>(() => {
@@ -245,6 +164,8 @@ export function useAnalytics(initialTimeRange: TimeRange = '30d') {
     categoryDistribution,
     userActivity,
     personalStats,
+    marketHealth,
+    predictiveInsights,
     
     // State
     isLoading,

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -22,6 +22,8 @@ export function AnalyticsPage() {
     categoryDistribution,
     userActivity,
     personalStats,
+    marketHealth,
+    predictiveInsights,
     isLoading,
     timeRange,
     setTimeRange,
@@ -166,6 +168,64 @@ export function AnalyticsPage() {
                 {topMarkets.slice(0, 5).map((market, index) => (
                   <TopMarketCard key={market.id} market={market} rank={index + 1} />
                 ))}
+              </div>
+            </section>
+
+            {/* Market Health and Predictive Insights */}
+            <section className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div className="bg-neutral-900/50 rounded-xl border border-neutral-800 p-6">
+                <h3 className="text-lg font-semibold text-white mb-4">Market Health</h3>
+                {!marketHealth ? (
+                  <p className="text-neutral-500">No market health data available</p>
+                ) : (
+                  <div className="grid grid-cols-2 gap-4 text-sm">
+                    <div>
+                      <p className="text-neutral-500">Active Rate</p>
+                      <p className="text-white font-semibold">{marketHealth.activeRate.toFixed(1)}%</p>
+                    </div>
+                    <div>
+                      <p className="text-neutral-500">Resolved Rate</p>
+                      <p className="text-white font-semibold">{marketHealth.resolvedRate.toFixed(1)}%</p>
+                    </div>
+                    <div>
+                      <p className="text-neutral-500">Average Pool</p>
+                      <p className="text-white font-semibold">{marketHealth.averagePoolFormatted} STX</p>
+                    </div>
+                    <div>
+                      <p className="text-neutral-500">Median Pool</p>
+                      <p className="text-white font-semibold">{marketHealth.medianPoolFormatted} STX</p>
+                    </div>
+                    <div>
+                      <p className="text-neutral-500">Largest Pool</p>
+                      <p className="text-white font-semibold">{marketHealth.largestPoolFormatted} STX</p>
+                    </div>
+                    <div>
+                      <p className="text-neutral-500">Top 3 Concentration</p>
+                      <p className="text-white font-semibold">{marketHealth.concentrationTop3.toFixed(1)}%</p>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="bg-neutral-900/50 rounded-xl border border-neutral-800 p-6">
+                <h3 className="text-lg font-semibold text-white mb-4">Predictive Insights</h3>
+                {predictiveInsights.length === 0 ? (
+                  <p className="text-neutral-500">No predictive insights available</p>
+                ) : (
+                  <div className="space-y-3">
+                    {predictiveInsights.map((insight) => (
+                      <div key={insight.marketId} className="border border-neutral-800 rounded-lg p-3">
+                        <p className="text-sm text-white line-clamp-1">{insight.question}</p>
+                        <div className="mt-2 flex flex-wrap gap-3 text-xs text-neutral-400">
+                          <span>Projected winner: <span className="text-neutral-200">{insight.projectedWinner.toUpperCase()}</span></span>
+                          <span>Confidence: <span className="text-neutral-200">{insight.confidence.toFixed(1)}%</span></span>
+                          <span>Projected pool: <span className="text-neutral-200">{insight.projectedFinalPoolFormatted} STX</span></span>
+                          <span>Risk: <span className="text-neutral-200">{insight.risk.toUpperCase()}</span></span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
             </section>
           </div>

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -77,6 +77,24 @@ export interface PersonalStats {
   favoriteCategory?: string;
 }
 
+export interface MarketHealthStats {
+  activeRate: number;
+  resolvedRate: number;
+  averagePoolFormatted: string;
+  medianPoolFormatted: string;
+  largestPoolFormatted: string;
+  concentrationTop3: number;
+}
+
+export interface PredictiveInsight {
+  marketId: number;
+  question: string;
+  projectedWinner: 'yes' | 'no' | 'balanced';
+  confidence: number;
+  projectedFinalPoolFormatted: string;
+  risk: 'low' | 'medium' | 'high';
+}
+
 // Position history entry
 export interface PositionHistory {
   marketId: number;
@@ -101,6 +119,8 @@ export interface AnalyticsState {
   categoryDistribution: CategoryData[];
   userActivity: UserActivityData[];
   personalStats: PersonalStats | null;
+  marketHealth: MarketHealthStats | null;
+  predictiveInsights: PredictiveInsight[];
   positionHistory: PositionHistory[];
   isLoading: boolean;
   error: string | null;

--- a/frontend/src/utils/__tests__/analytics.test.ts
+++ b/frontend/src/utils/__tests__/analytics.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildCategoryDistribution,
+  buildMarketHealth,
+  buildPredictiveInsights,
+  buildUserActivity,
+  buildVolumeHistory,
+  getDaysFromTimeRange,
+} from '../analytics';
+import { MarketOutcome, MarketStatus, type Market } from '../../types/market';
+
+const markets: Market[] = [
+  {
+    id: 1,
+    question: 'Will BTC hit 100k?',
+    creator: 'STTEST1',
+    endDate: 2000,
+    resolutionDate: 2100,
+    totalYesStake: 3_000_000,
+    totalNoStake: 1_000_000,
+    status: MarketStatus.ACTIVE,
+    outcome: MarketOutcome.NONE,
+    createdAt: Math.floor(Date.now() / 1000) - 24 * 60 * 60,
+  },
+  {
+    id: 2,
+    question: 'Will election candidate win?',
+    creator: 'STTEST2',
+    endDate: 3000,
+    resolutionDate: 3100,
+    totalYesStake: 2_000_000,
+    totalNoStake: 2_000_000,
+    status: MarketStatus.RESOLVED,
+    outcome: MarketOutcome.YES,
+    createdAt: Math.floor(Date.now() / 1000),
+  },
+];
+
+describe('analytics utilities', () => {
+  it('maps time ranges to day counts', () => {
+    expect(getDaysFromTimeRange('24h')).toBe(1);
+    expect(getDaysFromTimeRange('7d')).toBe(7);
+    expect(getDaysFromTimeRange('30d')).toBe(30);
+    expect(getDaysFromTimeRange('90d')).toBe(90);
+    expect(getDaysFromTimeRange('all')).toBe(365);
+  });
+
+  it('builds category distribution from market questions', () => {
+    const categories = buildCategoryDistribution(markets);
+    expect(categories.length).toBeGreaterThan(0);
+    expect(categories.reduce((sum, item) => sum + item.count, 0)).toBe(markets.length);
+  });
+
+  it('builds volume history and inferred user activity', () => {
+    const history = buildVolumeHistory(markets, 7);
+    expect(history).toHaveLength(7);
+    const activity = buildUserActivity(history);
+    expect(activity).toHaveLength(7);
+    expect(activity.every((row) => row.transactions >= 0)).toBe(true);
+  });
+
+  it('computes market health snapshot', () => {
+    const health = buildMarketHealth(markets);
+    expect(health).not.toBeNull();
+    expect(health?.activeRate).toBeGreaterThan(0);
+    expect(health?.largestPoolFormatted).toBeDefined();
+  });
+
+  it('generates predictive insights', () => {
+    const insights = buildPredictiveInsights(markets);
+    expect(insights.length).toBeGreaterThan(0);
+    expect(insights[0].confidence).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -1,0 +1,157 @@
+import type { Market } from '../types/market';
+import type {
+  CategoryData,
+  MarketHealthStats,
+  PredictiveInsight,
+  TimeRange,
+  UserActivityData,
+  VolumeDataPoint,
+} from '../types/analytics';
+import { CATEGORY_COLORS } from '../types/analytics';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function dayStart(timestampMs: number): number {
+  const date = new Date(timestampMs);
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+function formatDay(timestampMs: number): string {
+  return new Date(timestampMs).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+export function getDaysFromTimeRange(range: TimeRange): number {
+  switch (range) {
+    case '24h':
+      return 1;
+    case '7d':
+      return 7;
+    case '30d':
+      return 30;
+    case '90d':
+      return 90;
+    case 'all':
+      return 365;
+    default:
+      return 30;
+  }
+}
+
+function bucketMarketQuestion(question: string): string {
+  const q = question.toLowerCase();
+  if (q.includes('btc') || q.includes('bitcoin') || q.includes('eth') || q.includes('crypto')) return 'Crypto';
+  if (q.includes('election') || q.includes('president') || q.includes('vote')) return 'Politics';
+  if (q.includes('game') || q.includes('match') || q.includes('win') || q.includes('championship')) return 'Sports';
+  if (q.includes('movie') || q.includes('oscar') || q.includes('award')) return 'Entertainment';
+  if (q.includes('ai') || q.includes('tech') || q.includes('launch')) return 'Technology';
+  if (q.includes('stock') || q.includes('market') || q.includes('price')) return 'Finance';
+  return 'Other';
+}
+
+export function buildCategoryDistribution(markets: Market[]): CategoryData[] {
+  const counts: Record<string, number> = {};
+  for (const market of markets) {
+    const category = bucketMarketQuestion(market.question);
+    counts[category] = (counts[category] || 0) + 1;
+  }
+  const total = Object.values(counts).reduce((sum, count) => sum + count, 0);
+  return Object.entries(counts)
+    .map(([name, count]) => ({
+      name,
+      count,
+      value: total > 0 ? (count / total) * 100 : 0,
+      color: CATEGORY_COLORS[name] || CATEGORY_COLORS.Other,
+    }))
+    .sort((a, b) => b.value - a.value);
+}
+
+export function buildVolumeHistory(markets: Market[], days: number): VolumeDataPoint[] {
+  const now = Date.now();
+  const start = dayStart(now - (days - 1) * DAY_MS);
+  const buckets = new Map<number, { volume: number; transactions: number }>();
+
+  for (let i = 0; i < days; i++) {
+    buckets.set(start + i * DAY_MS, { volume: 0, transactions: 0 });
+  }
+
+  for (const market of markets) {
+    const ts = market.createdAt * 1000;
+    const bucket = dayStart(ts);
+    if (!buckets.has(bucket)) continue;
+    const item = buckets.get(bucket);
+    if (!item) continue;
+    const pool = market.totalYesStake + market.totalNoStake;
+    item.volume += pool;
+    item.transactions += Math.max(1, Math.floor(pool / 1_000_000));
+  }
+
+  return Array.from(buckets.entries()).map(([timestamp, values]) => ({
+    date: formatDay(timestamp),
+    timestamp,
+    volume: values.volume,
+    volumeFormatted: (values.volume / 1_000_000).toLocaleString(undefined, { maximumFractionDigits: 2 }),
+    transactions: values.transactions,
+  }));
+}
+
+export function buildUserActivity(volumeHistory: VolumeDataPoint[]): UserActivityData[] {
+  return volumeHistory.map((point) => {
+    const activeUsers = Math.max(1, Math.ceil(point.transactions * 0.7));
+    const newUsers = Math.max(0, Math.round(activeUsers * 0.12));
+    return {
+      date: point.date,
+      activeUsers,
+      newUsers,
+      transactions: point.transactions,
+    };
+  });
+}
+
+export function buildMarketHealth(markets: Market[]): MarketHealthStats | null {
+  if (markets.length === 0) return null;
+
+  const pools = markets.map((m) => m.totalYesStake + m.totalNoStake).sort((a, b) => a - b);
+  const sumPools = pools.reduce((sum, value) => sum + value, 0);
+  const largestPool = pools[pools.length - 1] || 0;
+  const top3 = pools.slice(-3).reduce((sum, value) => sum + value, 0);
+  const medianPool = pools[Math.floor(pools.length / 2)] || 0;
+  const activeMarkets = markets.filter((m) => m.status === 0).length;
+  const resolvedMarkets = markets.filter((m) => m.status === 1).length;
+
+  return {
+    activeRate: (activeMarkets / markets.length) * 100,
+    resolvedRate: (resolvedMarkets / markets.length) * 100,
+    averagePoolFormatted: (sumPools / markets.length / 1_000_000).toLocaleString(undefined, { maximumFractionDigits: 2 }),
+    medianPoolFormatted: (medianPool / 1_000_000).toLocaleString(undefined, { maximumFractionDigits: 2 }),
+    largestPoolFormatted: (largestPool / 1_000_000).toLocaleString(undefined, { maximumFractionDigits: 2 }),
+    concentrationTop3: sumPools > 0 ? (top3 / sumPools) * 100 : 0,
+  };
+}
+
+export function buildPredictiveInsights(markets: Market[]): PredictiveInsight[] {
+  return markets
+    .map((market) => {
+      const yes = market.totalYesStake;
+      const no = market.totalNoStake;
+      const pool = yes + no;
+      const imbalance = pool > 0 ? Math.abs(yes - no) / pool : 0;
+      const confidence = Math.min(99, Math.round((50 + imbalance * 50) * 10) / 10);
+      const projectedFinalPool = Math.round(pool * 1.18);
+      const projectedWinner: 'yes' | 'no' | 'balanced' =
+        yes === no ? 'balanced' : yes > no ? 'yes' : 'no';
+      const risk: 'low' | 'medium' | 'high' =
+        imbalance > 0.35 ? 'low' : imbalance > 0.15 ? 'medium' : 'high';
+      return {
+        marketId: market.id,
+        question: market.question,
+        projectedWinner,
+        confidence,
+        projectedFinalPoolFormatted: (projectedFinalPool / 1_000_000).toLocaleString(undefined, {
+          maximumFractionDigits: 2,
+        }),
+        risk,
+      };
+    })
+    .sort((a, b) => b.confidence - a.confidence)
+    .slice(0, 5);
+}


### PR DESCRIPTION
## Summary\n- add deterministic analytics builders for volume history, activity, market health, and predictive insights\n- refactor analytics hook to remove random data generation and consume reusable utilities\n- extend analytics page with market health and predictive insights sections\n- add focused tests for analytics utility calculations\n\n## Validation\n- cd frontend && npm run test:run\n- cd frontend && npm run build\n\nCloses #9