### PR TITLE
Support concurrent repeated stakes with stake history tracking

### DIFF
--- a/frontend/src/hooks/useStake.ts
+++ b/frontend/src/hooks/useStake.ts
@@ -5,6 +5,7 @@ import { MARKET_CONTRACT } from '../config/contracts';
 import { stxToMicroStx, MIN_STAKE, MAX_STAKE } from '../constants';
 import { useWallet } from '../components/WalletProvider';
 import { validateAmount, validateMarketId } from '../utils/validation';
+import { addStakeHistoryEntry, type StakeOutcome } from '../utils/stakeHistory';
 
 interface UseStakeReturn {
   placeYesStake: (marketId: number, amount: number, onSuccess?: () => void) => Promise<void>;
@@ -32,6 +33,7 @@ export function useStake(): UseStakeReturn {
       marketId: number,
       amount: number,
       functionName: 'place-yes-stake' | 'place-no-stake',
+      outcome: StakeOutcome,
       onSuccess?: () => void
     ) => {
       if (!address) {
@@ -73,6 +75,14 @@ export function useStake(): UseStakeReturn {
           postConditions,
           onFinish: (data) => {
             setTxId(data.txId);
+            addStakeHistoryEntry({
+              txId: data.txId,
+              marketId,
+              userAddress: address,
+              outcome,
+              amountStx: amount,
+              timestamp: Date.now(),
+            });
             setIsLoading(false);
             onSuccess?.();
           },
@@ -91,13 +101,13 @@ export function useStake(): UseStakeReturn {
 
   const placeYesStake = useCallback(
     (marketId: number, amount: number, onSuccess?: () => void) =>
-      placeStake(marketId, amount, 'place-yes-stake', onSuccess),
+      placeStake(marketId, amount, 'place-yes-stake', 'yes', onSuccess),
     [placeStake]
   );
 
   const placeNoStake = useCallback(
     (marketId: number, amount: number, onSuccess?: () => void) =>
-      placeStake(marketId, amount, 'place-no-stake', onSuccess),
+      placeStake(marketId, amount, 'place-no-stake', 'no', onSuccess),
     [placeStake]
   );
 

--- a/frontend/src/pages/TradePage.tsx
+++ b/frontend/src/pages/TradePage.tsx
@@ -11,6 +11,7 @@ import { useStake } from '../hooks/useStake';
 import { useRealtimeSignal } from '../hooks/useRealtimeSignal';
 import { validateAmount, validateMarketId } from '../utils/validation';
 import { SocialButtons } from '../components/SocialButtons';
+import { getStakeHistoryForMarketUser, getStakeHistoryTotals, type StakeHistoryEntry } from '../utils/stakeHistory';
 
 /**
  * TradePage Component
@@ -32,7 +33,8 @@ export function TradePage() {
     return validateMarketId(marketId);
   }, [marketId]);
   
-  const { isConnected, connect } = useWallet();
+  const { isConnected, connect, address } = useWallet();
+  const userAddress = isConnected ? address : null;
   const { placeYesStake, placeNoStake, isLoading: isStaking, error: stakeError, txId } = useStake();
   const { signal, source, isSocketConnected } = useRealtimeSignal({ enabled: true });
   
@@ -42,6 +44,7 @@ export function TradePage() {
   const [selectedOutcome, setSelectedOutcome] = useState<'yes' | 'no' | null>(null);
   const [stakeAmount, setStakeAmount] = useState<string>('10');
   const [tradeSuccess, setTradeSuccess] = useState(false);
+  const [stakeHistory, setStakeHistory] = useState<StakeHistoryEntry[]>([]);
   // Note: validationError stored for future UI display of validation errors
   const [, setValidationError] = useState<string | null>(null);
 
@@ -118,7 +121,6 @@ export function TradePage() {
     
     // Reset success state before new trade
     resetTradeState();
-    resetTradeState();
     
     const onSuccess = () => {
       // Update UI state instead of reloading page
@@ -181,6 +183,19 @@ export function TradePage() {
   const stake = parseFloat(stakeAmount) || 0;
   const potentialWinYes = stake > 0 && odds.yes > 0 ? (stake / odds.yes) * 100 : 0;
   const potentialWinNo = stake > 0 && odds.no > 0 ? (stake / odds.no) * 100 : 0;
+  const historyTotals = getStakeHistoryTotals(stakeHistory);
+
+  const refreshStakeHistory = useCallback(() => {
+    if (marketId === null || !userAddress) {
+      setStakeHistory([]);
+      return;
+    }
+    setStakeHistory(getStakeHistoryForMarketUser(marketId, userAddress));
+  }, [marketId, userAddress]);
+
+  useEffect(() => {
+    refreshStakeHistory();
+  }, [refreshStakeHistory, txId]);
 
   return (
     <div className="pt-[72px] min-h-screen">
@@ -429,6 +444,23 @@ export function TradePage() {
                     <div className="p-4 rounded-xl bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-sm">
                       <p className="font-semibold">Stake placed successfully!</p>
                       <p className="text-xs text-emerald-400/80">Market data will refresh shortly.</p>
+                    </div>
+                  )}
+
+                  {stakeHistory.length > 0 && (
+                    <div className="p-4 rounded-xl bg-neutral-900 border border-neutral-800">
+                      <p className="text-sm text-neutral-300 mb-2">Your stake history on this market</p>
+                      <div className="text-xs text-neutral-400 mb-2">
+                        YES: {historyTotals.yes.toFixed(2)} STX • NO: {historyTotals.no.toFixed(2)} STX • TOTAL: {historyTotals.total.toFixed(2)} STX
+                      </div>
+                      <div className="max-h-32 overflow-auto space-y-1">
+                        {stakeHistory.slice(0, 6).map((entry) => (
+                          <div key={entry.txId} className="text-xs text-neutral-500 flex justify-between">
+                            <span>{entry.outcome.toUpperCase()} • {entry.amountStx.toFixed(2)} STX</span>
+                            <span>{new Date(entry.timestamp).toLocaleTimeString()}</span>
+                          </div>
+                        ))}
+                      </div>
                     </div>
                   )}
 

--- a/frontend/src/utils/__tests__/stakeHistory.test.ts
+++ b/frontend/src/utils/__tests__/stakeHistory.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  addStakeHistoryEntry,
+  getStakeHistoryForMarketUser,
+  getStakeHistoryTotals,
+} from '../stakeHistory';
+
+describe('stakeHistory utilities', () => {
+  let store: Record<string, string>;
+
+  beforeEach(() => {
+    store = {};
+    vi.spyOn(localStorage, 'getItem').mockImplementation((key: string) => store[key] ?? null);
+    vi.spyOn(localStorage, 'setItem').mockImplementation((key: string, value: string) => {
+      store[key] = value;
+    });
+    vi.spyOn(localStorage, 'removeItem').mockImplementation((key: string) => {
+      delete store[key];
+    });
+    vi.spyOn(localStorage, 'clear').mockImplementation(() => {
+      store = {};
+    });
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('stores and retrieves stake history entries for a market and user', () => {
+    addStakeHistoryEntry({
+      txId: '0x1',
+      marketId: 3,
+      userAddress: 'STUSER',
+      outcome: 'yes',
+      amountStx: 10,
+      timestamp: Date.now(),
+    });
+
+    addStakeHistoryEntry({
+      txId: '0x2',
+      marketId: 3,
+      userAddress: 'STUSER',
+      outcome: 'no',
+      amountStx: 20,
+      timestamp: Date.now(),
+    });
+
+    const entries = getStakeHistoryForMarketUser(3, 'STUSER');
+    expect(entries).toHaveLength(2);
+    expect(entries[0].txId).toBe('0x2');
+  });
+
+  it('computes yes/no/total stake history aggregates', () => {
+    const totals = getStakeHistoryTotals([
+      { txId: 'a', marketId: 1, userAddress: 'ST1', outcome: 'yes', amountStx: 5, timestamp: 1 },
+      { txId: 'b', marketId: 1, userAddress: 'ST1', outcome: 'no', amountStx: 2.5, timestamp: 2 },
+      { txId: 'c', marketId: 1, userAddress: 'ST1', outcome: 'yes', amountStx: 1.5, timestamp: 3 },
+    ]);
+
+    expect(totals.yes).toBe(6.5);
+    expect(totals.no).toBe(2.5);
+    expect(totals.total).toBe(9);
+  });
+});

--- a/frontend/src/utils/stakeHistory.ts
+++ b/frontend/src/utils/stakeHistory.ts
@@ -1,0 +1,50 @@
+export type StakeOutcome = 'yes' | 'no';
+
+export interface StakeHistoryEntry {
+  txId: string;
+  marketId: number;
+  userAddress: string;
+  outcome: StakeOutcome;
+  amountStx: number;
+  timestamp: number;
+}
+
+const STAKE_HISTORY_KEY = '0xcast-stake-history';
+const MAX_HISTORY = 200;
+
+function readHistory(): StakeHistoryEntry[] {
+  try {
+    const raw = localStorage.getItem(STAKE_HISTORY_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as StakeHistoryEntry[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeHistory(entries: StakeHistoryEntry[]): void {
+  localStorage.setItem(STAKE_HISTORY_KEY, JSON.stringify(entries.slice(0, MAX_HISTORY)));
+}
+
+export function addStakeHistoryEntry(entry: StakeHistoryEntry): void {
+  const existing = readHistory();
+  const deduped = existing.filter((item) => item.txId !== entry.txId);
+  deduped.unshift(entry);
+  writeHistory(deduped);
+}
+
+export function getStakeHistoryForMarketUser(marketId: number, userAddress: string): StakeHistoryEntry[] {
+  return readHistory().filter((entry) => entry.marketId === marketId && entry.userAddress === userAddress);
+}
+
+export function getStakeHistoryTotals(entries: StakeHistoryEntry[]): { yes: number; no: number; total: number } {
+  const yes = entries
+    .filter((entry) => entry.outcome === 'yes')
+    .reduce((sum, entry) => sum + entry.amountStx, 0);
+  const no = entries
+    .filter((entry) => entry.outcome === 'no')
+    .reduce((sum, entry) => sum + entry.amountStx, 0);
+
+  return { yes, no, total: yes + no };
+}


### PR DESCRIPTION
## Summary\n- add local stake history persistence for repeated stakes on the same market\n- persist successful stake submissions from  for both YES and NO outcomes\n- surface per-market per-user stake totals and recent stake entries in \n- add focused unit tests for stake history utilities\n\n## Validation\n- cd frontend && npm run test:run\n- cd frontend && npm run build\n\nCloses #4