### PR TITLE
Implement emergency pause guardrails across contracts and frontend

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -11,9 +11,9 @@ path = "contracts/oxcast.clar"
 epoch = "latest"
 
 # Legacy contracts (kept for reference, not deployed)
-# [contracts.market-core]
-# path = "contracts/market-core.clar"
-# epoch = "latest"
+[contracts.market-core]
+path = "contracts/market-core.clar"
+epoch = "latest"
 
 # [contracts.access-control]
 # path = "contracts/access-control.clar"

--- a/contracts/market-core.clar
+++ b/contracts/market-core.clar
@@ -44,6 +44,7 @@
 (define-constant ERR-MARKET-NOT-FINALIZED (err u116))
 (define-constant ERR-FINALIZATION-NOT-READY (err u117))
 (define-constant ERR-MARKET-NOT-DISPUTED (err u118))
+(define-constant ERR-CONTRACT-PAUSED (err u119))
 
 ;; Only the oracle integration contract may invoke oracle/dispute entrypoints
 (define-constant ORACLE-INTEGRATION .oracle-integration)
@@ -54,6 +55,12 @@
 
 ;; Dispute window for any resolution (~24 hours in blocks)
 (define-data-var dispute-period uint u144)
+
+;; Emergency pause switch (owner-controlled)
+(define-data-var contract-paused bool false)
+
+;; Contract owner (deployer principal)
+(define-constant CONTRACT-OWNER 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM)
 
 ;; ============================================
 ;; Data Variables
@@ -186,6 +193,14 @@
   )
 )
 
+;; Prevent write actions while contract is paused
+(define-private (assert-not-paused)
+  (if (var-get contract-paused)
+    ERR-CONTRACT-PAUSED
+    (ok true)
+  )
+)
+
 ;; ============================================
 ;; Public Functions
 ;; ============================================
@@ -204,6 +219,7 @@
       (resolution-deadline (+ resolution-date (var-get abandonment-period)))
     )
     ;; Validate that end-date is in the future
+    (try! (assert-not-paused))
     (asserts! (> end-date current-block) ERR-INVALID-DATES)
     
     ;; Validate that resolution-date is after end-date
@@ -264,6 +280,7 @@
         (map-get? user-positions { market-id: market-id, user: tx-sender })
       ))
     )
+    (try! (assert-not-paused))
     ;; Validate market is still active
     (asserts! (is-eq (get status market) MARKET-STATUS-ACTIVE) ERR-MARKET-ALREADY-RESOLVED)
     
@@ -303,6 +320,7 @@
         (map-get? user-positions { market-id: market-id, user: tx-sender })
       ))
     )
+    (try! (assert-not-paused))
     ;; Validate market is still active
     (asserts! (is-eq (get status market) MARKET-STATUS-ACTIVE) ERR-MARKET-ALREADY-RESOLVED)
     
@@ -640,6 +658,18 @@
   )
 )
 
+;; Owner-only emergency pause controls
+(define-public (set-contract-paused (paused bool))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-NOT-AUTHORIZED)
+    (ok (var-set contract-paused paused))
+  )
+)
+
+(define-read-only (is-contract-paused)
+  (var-get contract-paused)
+)
+
 (define-read-only (get-abandonment-period)
   (var-get abandonment-period))
 
@@ -649,4 +679,3 @@
       (is-eq (get status market) MARKET-STATUS-ACTIVE)
       (> stacks-block-height (get resolution-deadline market)))
     false))
-

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -64,6 +64,11 @@ plan:
     - id: 0
       transactions:
         - emulated-contract-publish:
+            contract-name: market-core
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/market-core.clar
+            clarity-version: 3
+        - emulated-contract-publish:
             contract-name: oxcast
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/oxcast.clar

--- a/frontend/src/hooks/__tests__/useContractPause.test.ts
+++ b/frontend/src/hooks/__tests__/useContractPause.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useContractPause } from '../useContractPause';
+
+const fetchCallReadOnlyFunctionMock = vi.fn();
+const cvToJSONMock = vi.fn();
+
+vi.mock('@stacks/transactions', () => ({
+  fetchCallReadOnlyFunction: (...args: unknown[]) => fetchCallReadOnlyFunctionMock(...args),
+  cvToJSON: (...args: unknown[]) => cvToJSONMock(...args),
+}));
+
+vi.mock('../../contexts/NetworkContext', () => ({
+  useNetwork: () => ({
+    stacksNetwork: {},
+  }),
+}));
+
+vi.mock('../../config/contracts', () => ({
+  MARKET_CONTRACT: {
+    address: 'STTESTADDRESS',
+    name: 'market-core',
+  },
+}));
+
+describe('useContractPause', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns paused=true when contract is paused', async () => {
+    fetchCallReadOnlyFunctionMock.mockResolvedValue({});
+    cvToJSONMock.mockReturnValue({ type: 'bool', value: true });
+
+    const { result } = renderHook(() => useContractPause());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isPaused).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('surfaces read-only fetch errors', async () => {
+    fetchCallReadOnlyFunctionMock.mockRejectedValue(new Error('network failed'));
+
+    const { result } = renderHook(() => useContractPause());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isPaused).toBe(false);
+    expect(result.current.error).toContain('network failed');
+  });
+});

--- a/frontend/src/hooks/useContractPause.ts
+++ b/frontend/src/hooks/useContractPause.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from 'react';
+import { cvToJSON, fetchCallReadOnlyFunction } from '@stacks/transactions';
+import { MARKET_CONTRACT } from '../config/contracts';
+import { useNetwork } from '../contexts/NetworkContext';
+
+export function useContractPause() {
+  const { stacksNetwork } = useNetwork();
+  const [isPaused, setIsPaused] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const response = await fetchCallReadOnlyFunction({
+        network: stacksNetwork,
+        contractAddress: MARKET_CONTRACT.address,
+        contractName: MARKET_CONTRACT.name,
+        functionName: 'is-contract-paused',
+        functionArgs: [],
+        senderAddress: MARKET_CONTRACT.address,
+      });
+
+      const parsed = cvToJSON(response);
+      if (parsed.type !== 'bool') {
+        throw new Error('Unexpected pause status response');
+      }
+
+      setIsPaused(parsed.value);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch pause state');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [stacksNetwork]);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { isPaused, isLoading, error, refetch };
+}

--- a/frontend/src/hooks/useMarketCreation.ts
+++ b/frontend/src/hooks/useMarketCreation.ts
@@ -26,6 +26,7 @@
 import { useState, useCallback } from 'react';
 import { useContract } from './useContract';
 import type { CreateMarketFormData } from '../types/market';
+import { useContractPause } from './useContractPause';
 
 interface MarketCreationState {
   isCreating: boolean;
@@ -37,6 +38,7 @@ interface MarketCreationState {
 interface UseMarketCreationReturn {
   createMarket: (data: CreateMarketFormData) => Promise<void>;
   state: MarketCreationState;
+  isContractPaused: boolean;
   resetState: () => void;
 }
 
@@ -49,10 +51,16 @@ const initialState: MarketCreationState = {
 
 export function useMarketCreation(): UseMarketCreationReturn {
   const { createMarket: createMarketContract } = useContract();
+  const { isPaused: isContractPaused } = useContractPause();
   const [state, setState] = useState<MarketCreationState>(initialState);
 
   const createMarket = useCallback(
     async (data: CreateMarketFormData) => {
+      if (isContractPaused) {
+        const pauseError = 'Market creation is temporarily paused by protocol administrators';
+        setState(prev => ({ ...prev, isCreating: false, error: pauseError, success: false }));
+        throw new Error(pauseError);
+      }
       setState(prev => ({ ...prev, isCreating: true, error: null }));
 
       try {
@@ -90,7 +98,7 @@ export function useMarketCreation(): UseMarketCreationReturn {
         throw error;
       }
     },
-    [createMarketContract]
+    [createMarketContract, isContractPaused]
   );
 
   const resetState = useCallback(() => {
@@ -100,6 +108,7 @@ export function useMarketCreation(): UseMarketCreationReturn {
   return {
     createMarket,
     state,
+    isContractPaused,
     resetState,
   };
 }

--- a/frontend/src/hooks/useMultiMarketCreation.ts
+++ b/frontend/src/hooks/useMultiMarketCreation.ts
@@ -4,6 +4,7 @@ import { uintCV, stringUtf8CV, listCV, PostConditionMode } from '@stacks/transac
 import { useWallet } from '../components/WalletProvider';
 import { useNetwork } from '../contexts/NetworkContext';
 import { MARKET_MULTI_CONTRACT } from '../config/contracts';
+import { useContractPause } from './useContractPause';
 
 export interface CreateMultiMarketInput {
   question: string;
@@ -29,6 +30,7 @@ const initialState: MultiMarketCreationState = {
 export function useMultiMarketCreation() {
   const { isConnected } = useWallet();
   const { stacksNetwork } = useNetwork();
+  const { isPaused: isContractPaused } = useContractPause();
   const [state, setState] = useState<MultiMarketCreationState>(initialState);
 
   const createMultiMarket = useCallback(
@@ -38,6 +40,10 @@ export function useMultiMarketCreation() {
 
       if (!isConnected) {
         setState({ ...initialState, error: 'Wallet not connected' });
+        return;
+      }
+      if (isContractPaused) {
+        setState({ ...initialState, error: 'Market creation is temporarily paused by protocol administrators' });
         return;
       }
 
@@ -94,12 +100,12 @@ export function useMultiMarketCreation() {
         });
       }
     },
-    [isConnected, stacksNetwork]
+    [isConnected, stacksNetwork, isContractPaused]
   );
 
   const resetState = useCallback(() => {
     setState(initialState);
   }, []);
 
-  return { createMultiMarket, state, resetState };
+  return { createMultiMarket, state, resetState, isContractPaused };
 }

--- a/frontend/src/hooks/useMultiStake.ts
+++ b/frontend/src/hooks/useMultiStake.ts
@@ -6,6 +6,7 @@ import { useWallet } from '../components/WalletProvider';
 import { useNetwork } from '../contexts/NetworkContext';
 import { MARKET_MULTI_CONTRACT } from '../config/contracts';
 import { validateAmount, validateMarketId } from '../utils/validation';
+import { useContractPause } from './useContractPause';
 
 interface UseMultiStakeReturn {
   placeOutcomeStake: (
@@ -17,12 +18,14 @@ interface UseMultiStakeReturn {
   isLoading: boolean;
   error: string | null;
   txId: string | null;
+  isContractPaused: boolean;
   reset: () => void;
 }
 
 export function useMultiStake(): UseMultiStakeReturn {
   const { address } = useWallet();
   const { stacksNetwork } = useNetwork();
+  const { isPaused: isContractPaused } = useContractPause();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [txId, setTxId] = useState<string | null>(null);
@@ -37,6 +40,10 @@ export function useMultiStake(): UseMultiStakeReturn {
     async (marketId: number, outcomeIndex: number, amount: number, onSuccess?: () => void) => {
       if (!address) {
         setError('Wallet not connected');
+        return;
+      }
+      if (isContractPaused) {
+        setError('Staking is temporarily paused by protocol administrators');
         return;
       }
 
@@ -88,8 +95,8 @@ export function useMultiStake(): UseMultiStakeReturn {
         setIsLoading(false);
       }
     },
-    [address, stacksNetwork]
+    [address, stacksNetwork, isContractPaused]
   );
 
-  return { placeOutcomeStake, isLoading, error, txId, reset };
+  return { placeOutcomeStake, isLoading, error, txId, isContractPaused, reset };
 }

--- a/frontend/src/hooks/useStake.ts
+++ b/frontend/src/hooks/useStake.ts
@@ -6,6 +6,7 @@ import { stxToMicroStx, MIN_STAKE, MAX_STAKE } from '../constants';
 import { useWallet } from '../components/WalletProvider';
 import { validateAmount, validateMarketId } from '../utils/validation';
 import { addStakeHistoryEntry, type StakeOutcome } from '../utils/stakeHistory';
+import { useContractPause } from './useContractPause';
 
 interface UseStakeReturn {
   placeYesStake: (marketId: number, amount: number, onSuccess?: () => void) => Promise<void>;
@@ -13,6 +14,7 @@ interface UseStakeReturn {
   isLoading: boolean;
   error: string | null;
   txId: string | null;
+  isContractPaused: boolean;
   reset: () => void;
 }
 
@@ -21,6 +23,7 @@ export function useStake(): UseStakeReturn {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [txId, setTxId] = useState<string | null>(null);
+  const { isPaused: isContractPaused, refetch: refetchPauseState } = useContractPause();
 
   const reset = useCallback(() => {
     setIsLoading(false);
@@ -38,6 +41,10 @@ export function useStake(): UseStakeReturn {
     ) => {
       if (!address) {
         setError('Wallet not connected');
+        return;
+      }
+      if (isContractPaused) {
+        setError('Staking is temporarily paused by protocol administrators');
         return;
       }
 
@@ -84,6 +91,7 @@ export function useStake(): UseStakeReturn {
               timestamp: Date.now(),
             });
             setIsLoading(false);
+            refetchPauseState();
             onSuccess?.();
           },
           onCancel: () => {
@@ -96,7 +104,7 @@ export function useStake(): UseStakeReturn {
         setIsLoading(false);
       }
     },
-    [address]
+    [address, isContractPaused, refetchPauseState]
   );
 
   const placeYesStake = useCallback(
@@ -111,5 +119,5 @@ export function useStake(): UseStakeReturn {
     [placeStake]
   );
 
-  return { placeYesStake, placeNoStake, isLoading, error, txId, reset };
+  return { placeYesStake, placeNoStake, isLoading, error, txId, isContractPaused, reset };
 }

--- a/frontend/src/pages/CreateMarketPage.tsx
+++ b/frontend/src/pages/CreateMarketPage.tsx
@@ -27,7 +27,7 @@ import type { CreateMarketFormData } from '../types/market';
 export function CreateMarketPage() {
   const navigate = useNavigate();
   const { isConnected, connect } = useWallet();
-  const { createMarket, state, resetState } = useMarketCreation();
+  const { createMarket, state, resetState, isContractPaused } = useMarketCreation();
   
   const [redirecting, setRedirecting] = useState(false);
 
@@ -240,9 +240,22 @@ export function CreateMarketPage() {
         ) : (
           /* Create Form */
           <div style={cardStyle}>
+            {isContractPaused && (
+              <div style={{
+                marginBottom: '16px',
+                padding: '12px 14px',
+                border: '1px solid #F59E0B55',
+                backgroundColor: '#F59E0B22',
+                borderRadius: '10px',
+                color: '#FCD34D',
+                fontSize: '14px',
+              }}>
+                Market creation is temporarily paused. Claim and refund operations remain available.
+              </div>
+            )}
             <MarketForm 
               onSubmit={handleSubmit}
-              isSubmitting={state.isCreating}
+              isSubmitting={state.isCreating || isContractPaused}
               error={state.error}
             />
           </div>

--- a/frontend/src/pages/CreateMultiMarketPage.tsx
+++ b/frontend/src/pages/CreateMultiMarketPage.tsx
@@ -8,7 +8,7 @@ function getCurrentBlockEstimate(): number {
 }
 
 export function CreateMultiMarketPage() {
-  const { createMultiMarket, state } = useMultiMarketCreation();
+  const { createMultiMarket, state, isContractPaused } = useMultiMarketCreation();
   const [question, setQuestion] = useState('');
   const [outcomes, setOutcomes] = useState(['', '', '']);
   const [durationDays, setDurationDays] = useState(7);
@@ -149,6 +149,11 @@ export function CreateMultiMarketPage() {
           )}
 
           {state.error && <p className="text-sm text-red-500">{state.error}</p>}
+          {isContractPaused && (
+            <p className="text-sm text-amber-500">
+              Market creation is temporarily paused. Claim and refund operations remain available.
+            </p>
+          )}
           {state.success && (
             <p className="text-sm text-emerald-500">
               Multi-outcome market creation transaction submitted successfully.
@@ -156,7 +161,7 @@ export function CreateMultiMarketPage() {
           )}
           {state.txId && <p className="text-xs text-neutral-500 break-all">Transaction: {state.txId}</p>}
 
-          <button type="submit" className="btn btn-primary" disabled={!canSubmit || state.isCreating}>
+          <button type="submit" className="btn btn-primary" disabled={!canSubmit || state.isCreating || isContractPaused}>
             {state.isCreating ? 'Creating Market...' : 'Create Multi-Outcome Market'}
           </button>
         </form>

--- a/frontend/src/pages/MultiTradePage.tsx
+++ b/frontend/src/pages/MultiTradePage.tsx
@@ -12,7 +12,7 @@ export function MultiTradePage() {
   const { id } = useParams<{ id: string }>();
   const marketId = id ? Number(id) : NaN;
   const { markets, isLoading, error, refetch } = useMultiMarkets();
-  const { placeOutcomeStake, isLoading: isStaking, error: stakeError, txId } = useMultiStake();
+  const { placeOutcomeStake, isLoading: isStaking, error: stakeError, txId, isContractPaused } = useMultiStake();
   const { signal, source, isSocketConnected } = useRealtimeSignal({ enabled: true });
   const { isConnected, connect } = useWallet();
   const [selectedOutcome, setSelectedOutcome] = useState<number | null>(null);
@@ -126,6 +126,11 @@ export function MultiTradePage() {
               </button>
             ) : (
               <>
+                {isContractPaused && (
+                  <p className="text-sm text-amber-500">
+                    New stakes are temporarily paused. Claim and refund operations remain available.
+                  </p>
+                )}
                 <input
                   type="number"
                   min={MIN_STAKE}
@@ -140,7 +145,7 @@ export function MultiTradePage() {
                 <button
                   type="button"
                   className="btn btn-primary"
-                  disabled={selectedOutcome === null || !stakeValidation.isValid || isStaking}
+                  disabled={selectedOutcome === null || !stakeValidation.isValid || isStaking || isContractPaused}
                   onClick={handleStake}
                 >
                   {isStaking ? 'Submitting...' : 'Stake on Selected Outcome'}

--- a/frontend/src/pages/TradePage.tsx
+++ b/frontend/src/pages/TradePage.tsx
@@ -35,7 +35,7 @@ export function TradePage() {
   
   const { isConnected, connect, address } = useWallet();
   const userAddress = isConnected ? address : null;
-  const { placeYesStake, placeNoStake, isLoading: isStaking, error: stakeError, txId } = useStake();
+  const { placeYesStake, placeNoStake, isLoading: isStaking, error: stakeError, txId, isContractPaused } = useStake();
   const { signal, source, isSocketConnected } = useRealtimeSignal({ enabled: true });
   
   const [market, setMarket] = useState<Market | null>(null);
@@ -343,6 +343,11 @@ export function TradePage() {
                 </div>
               ) : (
                 <div className="space-y-6 sm:space-y-8">
+                  {isContractPaused && (
+                    <div className="p-4 rounded-xl bg-amber-500/10 border border-amber-500/20 text-amber-300 text-sm">
+                      New stakes are temporarily paused. Claim and refund operations remain available.
+                    </div>
+                  )}
                   {/* Outcome Selection */}
                   <div>
                     <label className="block text-sm text-neutral-400 mb-3 sm:mb-4">Select Outcome</label>
@@ -467,7 +472,7 @@ export function TradePage() {
                   {/* Trade Button */}
                   <button
                     onClick={handleTrade}
-                    disabled={!selectedOutcome || !stakeAmount || isStaking || stake < MIN_STAKE}
+                    disabled={!selectedOutcome || !stakeAmount || isStaking || stake < MIN_STAKE || isContractPaused}
                     className={`w-full py-4 rounded-xl font-semibold text-white transition-all disabled:opacity-50 disabled:cursor-not-allowed ${
                       selectedOutcome === 'yes' ? 'bg-emerald-600 hover:bg-emerald-500' :
                       selectedOutcome === 'no' ? 'bg-rose-600 hover:bg-rose-500' :

--- a/frontend/src/types/market.ts
+++ b/frontend/src/types/market.ts
@@ -26,6 +26,7 @@ export interface Market {
   status: MarketStatus;
   outcome: MarketOutcome;
   createdAt: number;
+  paused?: boolean;
 }
 
 export interface Position {

--- a/frontend/src/utils/__tests__/helpers.test.ts
+++ b/frontend/src/utils/__tests__/helpers.test.ts
@@ -38,6 +38,7 @@ describe('parseMarketData', () => {
       status: MarketStatus.ACTIVE,
       outcome: MarketOutcome.NONE,
       createdAt: 1703980800,
+      paused: undefined,
     });
   });
 

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -14,6 +14,7 @@ export function parseMarketData(marketId: number, rawData: any): Market {
     status: Number(rawData.status) as MarketStatus,
     outcome: Number(rawData.outcome) as MarketOutcome,
     createdAt: Number(rawData['created-at']),
+    paused: rawData.paused !== undefined ? Boolean(rawData.paused) : undefined,
   };
 }
 

--- a/tests/market-core.test.ts
+++ b/tests/market-core.test.ts
@@ -1003,4 +1003,160 @@ describe("market-core contract tests", () => {
             expect(loserClaim.result).toBeErr(Cl.uint(109)); // ERR-NO-WINNINGS
         });
     });
+
+    describe("Emergency Pause", () => {
+        it("should allow only owner to set pause state", () => {
+            const unauthorized = simnet.callPublicFn(
+                contractName,
+                "set-contract-paused",
+                [Cl.bool(true)],
+                wallet1
+            );
+            expect(unauthorized.result).toBeErr(Cl.uint(100)); // ERR-NOT-AUTHORIZED
+
+            const authorized = simnet.callPublicFn(
+                contractName,
+                "set-contract-paused",
+                [Cl.bool(true)],
+                deployer
+            );
+            expect(authorized.result).toBeOk({ type: "true" } as any);
+
+            const paused = simnet.callReadOnlyFn(contractName, "is-contract-paused", [], deployer);
+            expect(paused.result).toEqual({ type: "true" });
+        });
+
+        it("should block create-market while paused", () => {
+            const currentBlock = simnet.blockHeight;
+            const pause = simnet.callPublicFn(
+                contractName,
+                "set-contract-paused",
+                [Cl.bool(true)],
+                deployer
+            );
+            expect(pause.result).toBeOk({ type: "true" } as any);
+
+            const create = simnet.callPublicFn(
+                contractName,
+                "create-market",
+                [
+                    Cl.stringAscii("Pause should block creation"),
+                    Cl.uint(currentBlock + 50),
+                    Cl.uint(currentBlock + 100),
+                    Cl.uint(1),
+                ],
+                deployer
+            );
+            expect(create.result).toBeErr(Cl.uint(119)); // ERR-CONTRACT-PAUSED
+        });
+
+        it("should block both stake entrypoints while paused", () => {
+            const currentBlock = simnet.blockHeight;
+            const create = simnet.callPublicFn(
+                contractName,
+                "create-market",
+                [
+                    Cl.stringAscii("Pause should block staking"),
+                    Cl.uint(currentBlock + 50),
+                    Cl.uint(currentBlock + 100),
+                    Cl.uint(1),
+                ],
+                deployer
+            );
+            expect(create.result).toBeOk(Cl.uint(0));
+
+            const pause = simnet.callPublicFn(
+                contractName,
+                "set-contract-paused",
+                [Cl.bool(true)],
+                deployer
+            );
+            expect(pause.result).toBeOk({ type: "true" } as any);
+
+            const yesStake = simnet.callPublicFn(
+                contractName,
+                "place-yes-stake",
+                [Cl.uint(0), Cl.uint(1_000_000)],
+                wallet1
+            );
+            expect(yesStake.result).toBeErr(Cl.uint(119)); // ERR-CONTRACT-PAUSED
+
+            const noStake = simnet.callPublicFn(
+                contractName,
+                "place-no-stake",
+                [Cl.uint(0), Cl.uint(1_000_000)],
+                wallet2
+            );
+            expect(noStake.result).toBeErr(Cl.uint(119)); // ERR-CONTRACT-PAUSED
+        });
+
+        it("should allow claim-winnings while paused", () => {
+            const currentBlock = simnet.blockHeight;
+            const endDate = currentBlock + 10;
+            const resolutionDate = currentBlock + 20;
+
+            const create = simnet.callPublicFn(
+                contractName,
+                "create-market",
+                [
+                    Cl.stringAscii("Claims should remain available during pause"),
+                    Cl.uint(endDate),
+                    Cl.uint(resolutionDate),
+                    Cl.uint(1),
+                ],
+                deployer
+            );
+            expect(create.result).toBeOk(Cl.uint(0));
+
+            const yesStake = simnet.callPublicFn(
+                contractName,
+                "place-yes-stake",
+                [Cl.uint(0), Cl.uint(3_000_000)],
+                wallet1
+            );
+            expect(yesStake.result).toBeOk({ type: "true" } as any);
+
+            const noStake = simnet.callPublicFn(
+                contractName,
+                "place-no-stake",
+                [Cl.uint(0), Cl.uint(1_000_000)],
+                wallet2
+            );
+            expect(noStake.result).toBeOk({ type: "true" } as any);
+
+            simnet.mineEmptyBlocks(Math.max(0, resolutionDate - simnet.blockHeight));
+            const resolve = simnet.callPublicFn(
+                contractName,
+                "resolve-market",
+                [Cl.uint(0), Cl.uint(1)],
+                deployer
+            );
+            expect(resolve.result).toBeOk({ type: "true" } as any);
+
+            simnet.mineEmptyBlocks(150);
+            const finalize = simnet.callPublicFn(
+                contractName,
+                "finalize-market",
+                [Cl.uint(0)],
+                deployer
+            );
+            expect(finalize.result).toBeOk({ type: "true" } as any);
+
+            const pause = simnet.callPublicFn(
+                contractName,
+                "set-contract-paused",
+                [Cl.bool(true)],
+                deployer
+            );
+            expect(pause.result).toBeOk({ type: "true" } as any);
+
+            const claim = simnet.callPublicFn(
+                contractName,
+                "claim-winnings",
+                [Cl.uint(0)],
+                wallet1
+            );
+            expect(claim.result).toBeOk(Cl.uint(4_000_000));
+        });
+    });
 });


### PR DESCRIPTION
## Summary\n- add owner-controlled emergency pause support to \n- block new market creation and new stake placement while paused\n- keep claim and refund paths available during pause\n- surface pause status in frontend hooks and trade/create pages\n- add contract and frontend tests for pause behavior\n\n## Validation\n- npm run test -- --run tests/market-core.test.ts -t "Emergency Pause"\n- npm run test -- --run src/hooks/__tests__/useContractPause.test.ts src/utils/__tests__/helpers.test.ts src/utils/__tests__/validation.test.ts src/utils/validation.test.ts --maxWorkers=1\n- npm run build\n