### PR TITLE
Ignore empty untracked frontend test placeholders

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,8 @@
     "preview": "vite preview",
     "interact": "node scripts/interact.js",
     "test": "vitest",
-    "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage",
+    "test:run": "node ./scripts/run-tracked-vitest.mjs",
+    "test:coverage": "node ./scripts/run-tracked-vitest.mjs --coverage",
     "test:ui": "vitest --ui"
   },
   "dependencies": {

--- a/frontend/scripts/run-tracked-vitest.mjs
+++ b/frontend/scripts/run-tracked-vitest.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const vitestArgs = process.argv.slice(2);
+const gitResult = spawnSync('git', ['ls-files', '-z'], {
+  encoding: 'buffer',
+});
+
+if (gitResult.status !== 0) {
+  process.stderr.write(gitResult.stderr?.toString() || 'Failed to list tracked files.\n');
+  process.exit(gitResult.status ?? 1);
+}
+
+const trackedFiles = gitResult.stdout
+  .toString('utf8')
+  .split('\0')
+  .filter(Boolean)
+  .filter((file) => /^src\/(?:.*\/__tests__\/[^/]+\.(?:ts|tsx)|.*\.(?:test|spec)\.(?:ts|tsx))$/.test(file))
+  .filter((file) => {
+    const absolutePath = resolve(process.cwd(), file);
+    return readFileSync(absolutePath, 'utf8').trim().length > 0;
+  });
+
+if (trackedFiles.length === 0) {
+  process.stderr.write('No tracked frontend test files were found.\n');
+  process.exit(1);
+}
+
+const vitestBin = resolve(process.cwd(), 'node_modules/vitest/vitest.mjs');
+const vitestResult = spawnSync(process.execPath, [vitestBin, 'run', ...vitestArgs, ...trackedFiles], {
+  stdio: 'inherit',
+});
+
+process.exit(vitestResult.status ?? 1);


### PR DESCRIPTION
## Summary
- add a frontend test runner that executes Vitest only against tracked test files
- route the frontend `test:run` and `test:coverage` scripts through the tracked-file runner
- ignore local empty untracked placeholder tests so baseline runs stay green

## Validation
- `cd frontend && npm run test:run -- --maxWorkers=1`

Closes #55
