### PR TITLE
fix: respect active network in read-only hooks

### DIFF
--- a/frontend/src/__tests__/networkAwareHooks.test.tsx
+++ b/frontend/src/__tests__/networkAwareHooks.test.tsx
@@ -1,0 +1,220 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { STACKS_MAINNET, STACKS_TESTNET } from '@stacks/network';
+import { fetchCallReadOnlyFunction, cvToJSON } from '@stacks/transactions';
+import { NetworkType } from '../types/network';
+import { usePosition } from '../hooks/usePosition';
+import { useStakingData } from '../hooks/useStakingData';
+import { useNetwork } from '../contexts/NetworkContext';
+
+vi.mock('@stacks/transactions', async () => {
+  const actual = await vi.importActual<typeof import('@stacks/transactions')>('@stacks/transactions');
+  return {
+    ...actual,
+    fetchCallReadOnlyFunction: vi.fn(),
+    cvToJSON: vi.fn(),
+  };
+});
+
+vi.mock('../contexts/NetworkContext', () => ({
+  useNetwork: vi.fn(),
+}));
+
+const fetchCallReadOnlyFunctionMock = vi.mocked(fetchCallReadOnlyFunction);
+const cvToJSONMock = vi.mocked(cvToJSON);
+const useNetworkMock = vi.mocked(useNetwork);
+
+function mockNetworkContext(network: NetworkType) {
+  return network === NetworkType.MAINNET
+    ? {
+        network,
+        networkConfig: { apiUrl: 'https://api.mainnet.hiro.so' },
+        stacksNetwork: STACKS_MAINNET,
+        contractAddress: 'SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T',
+        contractName: '0xcast-v1',
+        isMainnet: true,
+        isTestnet: false,
+        setNetwork: vi.fn(),
+        toggleNetwork: vi.fn(),
+      }
+    : {
+        network,
+        networkConfig: { apiUrl: 'https://api.testnet.hiro.so' },
+        stacksNetwork: STACKS_TESTNET,
+        contractAddress: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
+        contractName: '0xcast-v1',
+        isMainnet: false,
+        isTestnet: true,
+        setNetwork: vi.fn(),
+        toggleNetwork: vi.fn(),
+      };
+}
+
+describe('network-aware read-only hooks', () => {
+  beforeEach(() => {
+    fetchCallReadOnlyFunctionMock.mockReset();
+    cvToJSONMock.mockReset();
+    useNetworkMock.mockReset();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses mainnet when fetching user positions on mainnet', async () => {
+    useNetworkMock.mockReturnValue(mockNetworkContext(NetworkType.MAINNET) as never);
+
+    fetchCallReadOnlyFunctionMock.mockImplementation(async ({ functionName }) => {
+      return { functionName } as never;
+    });
+
+    cvToJSONMock.mockImplementation((value: { functionName: string }) => {
+      if (value.functionName === 'get-user-position') {
+        return {
+          type: 'some',
+          value: {
+            'yes-stake': { value: '1000000' },
+            'no-stake': { value: '0' },
+            claimed: false,
+          },
+        };
+      }
+
+      return { type: 'none' };
+    });
+
+    renderHook(() => usePosition(12, 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM'));
+
+    await waitFor(() => {
+      expect(fetchCallReadOnlyFunctionMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(fetchCallReadOnlyFunctionMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        network: STACKS_MAINNET,
+        contractName: 'market-core',
+      })
+    );
+  });
+
+  it('uses testnet when fetching user positions on testnet', async () => {
+    useNetworkMock.mockReturnValue(mockNetworkContext(NetworkType.TESTNET) as never);
+
+    fetchCallReadOnlyFunctionMock.mockImplementation(async ({ functionName }) => {
+      return { functionName } as never;
+    });
+
+    cvToJSONMock.mockImplementation((value: { functionName: string }) => {
+      if (value.functionName === 'get-user-position') {
+        return {
+          type: 'some',
+          value: {
+            'yes-stake': { value: '1000000' },
+            'no-stake': { value: '0' },
+            claimed: false,
+          },
+        };
+      }
+
+      return { type: 'none' };
+    });
+
+    renderHook(() => usePosition(12, 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM'));
+
+    await waitFor(() => {
+      expect(fetchCallReadOnlyFunctionMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(fetchCallReadOnlyFunctionMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        network: STACKS_TESTNET,
+        contractName: 'market-core',
+      })
+    );
+  });
+
+  it('uses mainnet when fetching staking data on mainnet', async () => {
+    useNetworkMock.mockReturnValue(mockNetworkContext(NetworkType.MAINNET) as never);
+
+    fetchCallReadOnlyFunctionMock.mockImplementation(async ({ functionName }) => {
+      return { functionName } as never;
+    });
+
+    cvToJSONMock.mockImplementation((value: { functionName: string }) => {
+      if (value.functionName === 'get-total-staked') {
+        return { value: { value: '1000000' } };
+      }
+
+      if (value.functionName === 'get-stake') {
+        return {
+          value: {
+            amount: { value: '250000' },
+            'locked-until': { value: '100' },
+          },
+        };
+      }
+
+      if (value.functionName === 'get-balance') {
+        return { value: { value: '500000' } };
+      }
+
+      return { value: null };
+    });
+
+    const fetchMock = vi.mocked(global.fetch);
+    fetchMock.mockResolvedValue({
+      json: async () => ({ stacks_tip_height: 200 }),
+    } as Response);
+
+    renderHook(() => useStakingData('ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM'));
+
+    await waitFor(() => {
+      expect(fetchCallReadOnlyFunctionMock).toHaveBeenCalledTimes(3);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.mainnet.hiro.so/v2/info');
+  });
+
+  it('uses testnet when fetching staking data on testnet', async () => {
+    useNetworkMock.mockReturnValue(mockNetworkContext(NetworkType.TESTNET) as never);
+
+    fetchCallReadOnlyFunctionMock.mockImplementation(async ({ functionName }) => {
+      return { functionName } as never;
+    });
+
+    cvToJSONMock.mockImplementation((value: { functionName: string }) => {
+      if (value.functionName === 'get-total-staked') {
+        return { value: { value: '1000000' } };
+      }
+
+      if (value.functionName === 'get-stake') {
+        return {
+          value: {
+            amount: { value: '250000' },
+            'locked-until': { value: '100' },
+          },
+        };
+      }
+
+      if (value.functionName === 'get-balance') {
+        return { value: { value: '500000' } };
+      }
+
+      return { value: null };
+    });
+
+    const fetchMock = vi.mocked(global.fetch);
+    fetchMock.mockResolvedValue({
+      json: async () => ({ stacks_tip_height: 200 }),
+    } as Response);
+
+    renderHook(() => useStakingData('ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM'));
+
+    await waitFor(() => {
+      expect(fetchCallReadOnlyFunctionMock).toHaveBeenCalledTimes(3);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.testnet.hiro.so/v2/info');
+  });
+});

--- a/frontend/src/hooks/usePosition.ts
+++ b/frontend/src/hooks/usePosition.ts
@@ -1,14 +1,12 @@
 import { useState, useCallback, useEffect } from 'react';
 import { cvToJSON, fetchCallReadOnlyFunction, uintCV, principalCV } from '@stacks/transactions';
-import { STACKS_MAINNET, STACKS_TESTNET } from '@stacks/network';
 import type { Position } from '../types/market';
 import { parsePosition } from '../utils/helpers';
-import { MARKET_CONTRACT, CURRENT_NETWORK } from '../config/contracts';
-
-// Get the appropriate network based on configuration
-const getNetwork = () => CURRENT_NETWORK === 'mainnet' ? STACKS_MAINNET : STACKS_TESTNET;
+import { CONTRACT_NAMES, getContractAddress } from '../config/contracts';
+import { useNetwork } from '../contexts/NetworkContext';
 
 export function usePosition(marketId: number | null, userAddress: string | null) {
+  const { stacksNetwork, network } = useNetwork();
   const [position, setPosition] = useState<Position | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -23,14 +21,14 @@ export function usePosition(marketId: number | null, userAddress: string | null)
     setError(null);
 
     try {
-      const network = getNetwork();
+      const contractAddress = getContractAddress(CONTRACT_NAMES.MARKET_CORE, network);
       const result = await fetchCallReadOnlyFunction({
-        network,
-        contractAddress: MARKET_CONTRACT.address,
-        contractName: MARKET_CONTRACT.name,
+        network: stacksNetwork,
+        contractAddress,
+        contractName: CONTRACT_NAMES.MARKET_CORE,
         functionName: 'get-user-position',
         functionArgs: [uintCV(marketId), principalCV(userAddress)],
-        senderAddress: MARKET_CONTRACT.address,
+        senderAddress: contractAddress,
       });
 
       const jsonResult = cvToJSON(result);
@@ -44,7 +42,7 @@ export function usePosition(marketId: number | null, userAddress: string | null)
     } finally {
       setIsLoading(false);
     }
-  }, [marketId, userAddress]);
+  }, [marketId, userAddress, network, stacksNetwork]);
 
   // Auto-fetch position when marketId or userAddress changes
   useEffect(() => {

--- a/frontend/src/hooks/useStakingData.ts
+++ b/frontend/src/hooks/useStakingData.ts
@@ -1,11 +1,8 @@
 // Hook for fetching real staking data from the oxcast contract
 import { useState, useEffect, useCallback } from 'react';
 import { cvToJSON, fetchCallReadOnlyFunction, principalCV } from '@stacks/transactions';
-import { STACKS_MAINNET, STACKS_TESTNET } from '@stacks/network';
-import { TOKEN_CONTRACT, CURRENT_NETWORK } from '../config/contracts';
-
-// Get the appropriate network
-const getNetwork = () => CURRENT_NETWORK === 'mainnet' ? STACKS_MAINNET : STACKS_TESTNET;
+import { CONTRACT_NAMES, getContractAddress } from '../config/contracts';
+import { useNetwork } from '../contexts/NetworkContext';
 
 export interface StakingData {
   totalStaked: bigint;
@@ -17,6 +14,7 @@ export interface StakingData {
 }
 
 export function useStakingData(userAddress: string | null) {
+  const { network, networkConfig, stacksNetwork } = useNetwork();
   const [stakingData, setStakingData] = useState<StakingData>({
     totalStaked: 0n,
     userStaked: 0n,
@@ -33,16 +31,16 @@ export function useStakingData(userAddress: string | null) {
     setError(null);
 
     try {
-      const network = getNetwork();
+      const contractAddress = getContractAddress(CONTRACT_NAMES.OXCAST, network);
       
       // Fetch total staked
       const totalStakedResult = await fetchCallReadOnlyFunction({
-        network,
-        contractAddress: TOKEN_CONTRACT.address,
-        contractName: TOKEN_CONTRACT.name,
+        network: stacksNetwork,
+        contractAddress,
+        contractName: CONTRACT_NAMES.OXCAST,
         functionName: 'get-total-staked',
         functionArgs: [],
-        senderAddress: TOKEN_CONTRACT.address,
+        senderAddress: contractAddress,
       });
 
       const totalStakedJson = cvToJSON(totalStakedResult);
@@ -56,12 +54,12 @@ export function useStakingData(userAddress: string | null) {
       if (userAddress) {
         // Fetch user stake
         const userStakeResult = await fetchCallReadOnlyFunction({
-          network,
-          contractAddress: TOKEN_CONTRACT.address,
-          contractName: TOKEN_CONTRACT.name,
+          network: stacksNetwork,
+          contractAddress,
+          contractName: CONTRACT_NAMES.OXCAST,
           functionName: 'get-stake',
           functionArgs: [principalCV(userAddress)],
-          senderAddress: TOKEN_CONTRACT.address,
+          senderAddress: contractAddress,
         });
 
         const userStakeJson = cvToJSON(userStakeResult);
@@ -72,12 +70,12 @@ export function useStakingData(userAddress: string | null) {
 
         // Fetch user OXC balance
         const balanceResult = await fetchCallReadOnlyFunction({
-          network,
-          contractAddress: TOKEN_CONTRACT.address,
-          contractName: TOKEN_CONTRACT.name,
+          network: stacksNetwork,
+          contractAddress,
+          contractName: CONTRACT_NAMES.OXCAST,
           functionName: 'get-balance',
           functionArgs: [principalCV(userAddress)],
-          senderAddress: TOKEN_CONTRACT.address,
+          senderAddress: contractAddress,
         });
 
         const balanceJson = cvToJSON(balanceResult);
@@ -85,9 +83,7 @@ export function useStakingData(userAddress: string | null) {
       }
 
       // Fetch current block height from API
-      const apiUrl = CURRENT_NETWORK === 'mainnet' 
-        ? 'https://api.mainnet.hiro.so/v2/info'
-        : 'https://api.testnet.hiro.so/v2/info';
+      const apiUrl = `${networkConfig.apiUrl}/v2/info`;
       
       let currentBlock = 0;
       try {
@@ -114,7 +110,7 @@ export function useStakingData(userAddress: string | null) {
     } finally {
       setIsLoading(false);
     }
-  }, [userAddress]);
+  }, [userAddress, network, networkConfig.apiUrl, stacksNetwork]);
 
   useEffect(() => {
     fetchStakingData();


### PR DESCRIPTION
usePosition and useStakingData now read the active network from useNetwork, so read-only contract calls and Hiro API reads follow the selected network instead of stale mainnet state. I added focused tests for mainnet and testnet coverage, and lint passes. Full frontend build is currently blocked by an unrelated syntax error in frontend/src/utils/errorRecovery.ts.

Closes #61 