### PR TITLE
Feature/storage efficiency optimizations

### DIFF
--- a/contracts/liquidity-pool.clar
+++ b/contracts/liquidity-pool.clar
@@ -17,7 +17,6 @@
   uint ;; market-id
   {
     stx-balance: uint,
-    token-balances: (list 10 uint),
     total-shares: uint,
     active: bool
   })
@@ -42,7 +41,6 @@
     ;; In production, transfer STX to contract
     (ok (map-set liquidity-pools market-id {
       stx-balance: initial-stx,
-      token-balances: (list u0 u0), ;; Placeholder for outcome tokens
       total-shares: initial-stx,
       active: true
     }))))

--- a/frontend/src/hooks/useLiquidity.ts
+++ b/frontend/src/hooks/useLiquidity.ts
@@ -126,7 +126,6 @@ export function useLiquidity(): UseLiquidityReturn {
     try {
       const result = await callReadOnly<{
         'stx-balance': number;
-        'token-balances': number[];
         'total-shares': number;
         active: boolean;
       } | null>('get-pool', [encodeUint(marketId)]);
@@ -136,7 +135,7 @@ export function useLiquidity(): UseLiquidityReturn {
       return {
         marketId,
         stxBalance: BigInt(result['stx-balance'] ?? 0),
-        tokenBalances: result['token-balances'] ?? [],
+        tokenBalances: [],
         totalShares: BigInt(result['total-shares'] ?? 0),
         active: result.active ?? false,
       };

--- a/tests/liquidity.test.ts
+++ b/tests/liquidity.test.ts
@@ -25,7 +25,13 @@ describe("Liquidity Pool Tests", () => {
             [Cl.uint(marketId)],
             deployer
         );
-        expect(pool.result).not.toEqual(Cl.none());
+        expect(pool.result).toBeSome(
+            Cl.tuple({
+                "stx-balance": Cl.uint(initialStx),
+                "total-shares": Cl.uint(initialStx),
+                active: Cl.bool(true),
+            })
+        );
     });
 
     it("should allow adding liquidity", () => {


### PR DESCRIPTION
What changed
Removed the stored token-balances list from contracts/liquidity-pool.clar.
Kept the frontend liquidity hook compatible by returning an empty tokenBalances array instead of reading it from contract state.
Updated tests/liquidity.test.ts to assert the slimmer pool shape directly.
Why
token-balances was persisted on-chain but never used by contract logic. It added storage overhead without providing functional value, so removing it lowers contract size and reduces write costs.

Behavior
Pool creation, add liquidity, remove liquidity, and reward flows remain unchanged.
Read-only pool data still works for the fields the app actually uses.
The UI keeps the same pool interface shape.
Validation
npm test -- --run tests/liquidity.test.ts
npx eslint src/hooks/useLiquidity.ts

Closes #86 