### PR TITLE
Feature/fix block height fallback

### DIFF
--- a/scripts/governance-operations.ts
+++ b/scripts/governance-operations.ts
@@ -21,6 +21,7 @@ import {
     logTransaction,
     displayProgress,
     TransactionTracker,
+    getCurrentBlockHeight,
 } from './utils/transaction-helpers.js';
 
 // Load environment variables
@@ -42,19 +43,7 @@ const PROPOSAL_TYPES = {
     EMERGENCY_ACTION: 'emergency-action',
 };
 
-/**
- * Get current block height
- */
-async function getCurrentBlockHeight(): Promise<number> {
-    try {
-        const response = await fetch('https://api.mainnet.hiro.so/v2/info');
-        const data = await response.json();
-        return data.stacks_tip_height;
-    } catch (error) {
-        console.warn('Could not fetch current block height');
-        return 6040000; // Fallback
-    }
-}
+
 
 /**
  * Create a governance proposal

--- a/scripts/interact-contract.ts
+++ b/scripts/interact-contract.ts
@@ -13,6 +13,7 @@ import { generateWallet } from '@stacks/wallet-sdk';
 import prompts from 'prompts';
 import * as dotenv from 'dotenv';
 import { categoryFromQuestion } from './utils/market-categories.js';
+import { fetchCurrentBlockHeight } from './utils/block-height.js';
 import fs from 'fs';
 import toml from 'toml';
 import path from 'path';
@@ -32,19 +33,6 @@ const CONTRACT_NAME = 'market-core';
 // Network configuration
 const network = STACKS_MAINNET;
 
-/**
- * Get current Stacks block height from the network
- */
-async function getCurrentBlockHeight(): Promise<number> {
-    try {
-        const response = await fetch('https://api.mainnet.hiro.so/v2/info');
-        const data = await response.json();
-        return data.stacks_tip_height;
-    } catch (error) {
-        console.warn('Could not fetch current block height, using fallback');
-        return 6037876; // Fallback to approximate current height
-    }
-}
 
 // Stake amounts in microSTX (1 STX = 1,000,000 microSTX)
 const YES_STAKE_AMOUNT = 500000; // 0.5 STX
@@ -53,11 +41,10 @@ const NO_STAKE_AMOUNT = 300000;  // 0.3 STX
 // Market parameters
 const MARKET_QUESTION = "Will STX reach $5 by March 1st, 2026?";
 // Stacks produces ~144 blocks per day (10 min per block)
-// Current block ~6,037,876 (Jan 22, 2026)
 // Adding 5,000 blocks (~35 days) for end date
 // Adding 5,500 blocks (~38 days) for resolution date
-const END_BLOCK_HEIGHT = 6043000;      // ~35 days from now
-const RESOLUTION_BLOCK_HEIGHT = 6043500; // ~3 days after market closes
+const END_BLOCK_OFFSET = 5000;
+const RESOLUTION_BLOCK_OFFSET = 5500;
 
 /**
  * Get private key from Mainnet.toml by deriving from mnemonic
@@ -107,11 +94,11 @@ async function getPrivateKey(): Promise<string> {
 /**
  * Create a new prediction market
  */
-async function createMarket(privateKey: string, category: number): Promise<string> {
+async function createMarket(privateKey: string, category: number, endBlockHeight: number, resolutionBlockHeight: number): Promise<string> {
     console.log('\n📊 Creating market...');
     console.log(`Question: "${MARKET_QUESTION}"`);
-    console.log(`End block: ${END_BLOCK_HEIGHT}`);
-    console.log(`Resolution block: ${RESOLUTION_BLOCK_HEIGHT}`);
+    console.log(`End block: ${endBlockHeight}`);
+    console.log(`Resolution block: ${resolutionBlockHeight}`);
 
     const txOptions = {
         contractAddress: CONTRACT_ADDRESS,
@@ -119,8 +106,8 @@ async function createMarket(privateKey: string, category: number): Promise<strin
         functionName: 'create-market',
         functionArgs: [
             stringAsciiCV(MARKET_QUESTION),
-            uintCV(END_BLOCK_HEIGHT),
-            uintCV(RESOLUTION_BLOCK_HEIGHT),
+            uintCV(endBlockHeight),
+            uintCV(resolutionBlockHeight),
             uintCV(category),
         ],
         senderKey: privateKey,
@@ -247,16 +234,20 @@ async function main() {
     try {
         // Get current block height
         console.log('⏱️  Fetching current block height...');
-        const currentBlock = await getCurrentBlockHeight();
+        const currentBlock = await fetchCurrentBlockHeight('mainnet');
         console.log(`Current Stacks block: ${currentBlock.toLocaleString()}`);
-        console.log(`End block: ${END_BLOCK_HEIGHT.toLocaleString()} (${(END_BLOCK_HEIGHT - currentBlock).toLocaleString()} blocks away)`);
-        console.log(`Resolution block: ${RESOLUTION_BLOCK_HEIGHT.toLocaleString()}\n`);
+        
+        const endBlockHeight = currentBlock + END_BLOCK_OFFSET;
+        const resolutionBlockHeight = currentBlock + RESOLUTION_BLOCK_OFFSET;
+        
+        console.log(`End block: ${endBlockHeight.toLocaleString()} (${END_BLOCK_OFFSET.toLocaleString()} blocks away)`);
+        console.log(`Resolution block: ${resolutionBlockHeight.toLocaleString()}\n`);
 
         // Validate block heights are in the future
-        if (END_BLOCK_HEIGHT <= currentBlock) {
-            throw new Error(`❌ END_BLOCK_HEIGHT (${END_BLOCK_HEIGHT}) is in the past! Current block is ${currentBlock}. Please update the script with future block heights.`);
+        if (endBlockHeight <= currentBlock) {
+            throw new Error(`❌ END_BLOCK_HEIGHT (${endBlockHeight}) is in the past! Current block is ${currentBlock}.`);
         }
-        if (RESOLUTION_BLOCK_HEIGHT <= END_BLOCK_HEIGHT) {
+        if (resolutionBlockHeight <= endBlockHeight) {
             throw new Error(`❌ RESOLUTION_BLOCK_HEIGHT must be greater than END_BLOCK_HEIGHT`);
         }
 
@@ -269,7 +260,12 @@ async function main() {
         }
 
         // Step 1: Create market
-        const createMarketTxId = await createMarket(privateKey, categoryFromQuestion(MARKET_QUESTION));
+        const createMarketTxId = await createMarket(
+            privateKey, 
+            categoryFromQuestion(MARKET_QUESTION), 
+            endBlockHeight, 
+            resolutionBlockHeight
+        );
 
         // Wait for user to confirm market creation before proceeding
         console.log('\n⏳ Please wait for the market creation transaction to confirm...');

--- a/scripts/multi-outcome-trading.ts
+++ b/scripts/multi-outcome-trading.ts
@@ -21,6 +21,7 @@ import {
     logTransaction,
     displayProgress,
     TransactionTracker,
+    getCurrentBlockHeight,
 } from './utils/transaction-helpers.js';
 
 // Load environment variables
@@ -33,19 +34,7 @@ const MULTI_MARKET_CONTRACT = 'market-multi';
 // Network configuration
 const network = STACKS_MAINNET;
 
-/**
- * Get current block height
- */
-async function getCurrentBlockHeight(): Promise<number> {
-    try {
-        const response = await fetch('https://api.mainnet.hiro.so/v2/info');
-        const data = await response.json();
-        return data.stacks_tip_height;
-    } catch (error) {
-        console.warn('Could not fetch current block height');
-        return 6040000; // Fallback
-    }
-}
+
 
 /**
  * Create a multi-outcome market

--- a/scripts/utils/block-height.ts
+++ b/scripts/utils/block-height.ts
@@ -5,7 +5,8 @@ import prompts from 'prompts';
  */
 export async function fetchCurrentBlockHeight(
     network: 'mainnet' | 'testnet' | 'devnet' = 'mainnet',
-    maxRetries: number = 3
+    maxRetries: number = 3,
+    retryDelayMs: number = 2000
 ): Promise<number> {
     const apiUrl = network === 'mainnet'
         ? 'https://api.mainnet.hiro.so/v2/info'
@@ -29,8 +30,8 @@ export async function fetchCurrentBlockHeight(
         } catch (error) {
             if (attempt < maxRetries) {
                 console.warn(`⚠️  Block height fetch attempt ${attempt} failed: ${error instanceof Error ? error.message : String(error)}`);
-                console.warn(`   Retrying in 2s...`);
-                await new Promise(resolve => setTimeout(resolve, 2000));
+                console.warn(`   Retrying in ${retryDelayMs / 1000}s...`);
+                await new Promise(resolve => setTimeout(resolve, retryDelayMs));
             } else {
                 console.error(`\n❌ Failed to fetch current block height after ${maxRetries} attempts.`);
                 

--- a/scripts/utils/block-height.ts
+++ b/scripts/utils/block-height.ts
@@ -1,0 +1,57 @@
+import prompts from 'prompts';
+
+/**
+ * Fetch current Stacks block height with retry logic
+ */
+export async function fetchCurrentBlockHeight(
+    network: 'mainnet' | 'testnet' | 'devnet' = 'mainnet',
+    maxRetries: number = 3
+): Promise<number> {
+    const apiUrl = network === 'mainnet'
+        ? 'https://api.mainnet.hiro.so/v2/info'
+        : network === 'testnet'
+            ? 'https://api.testnet.hiro.so/v2/info'
+            : 'http://localhost:3999/v2/info';
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+            const response = await fetch(apiUrl, { signal: AbortSignal.timeout(5000) });
+
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+            }
+
+            const data = await response.json();
+            if (data && typeof data.stacks_tip_height === 'number') {
+                return data.stacks_tip_height;
+            }
+            throw new Error('Invalid response format from API');
+        } catch (error) {
+            if (attempt < maxRetries) {
+                console.warn(`⚠️  Block height fetch attempt ${attempt} failed: ${error instanceof Error ? error.message : String(error)}`);
+                console.warn(`   Retrying in 2s...`);
+                await new Promise(resolve => setTimeout(resolve, 2000));
+            } else {
+                console.error(`\n❌ Failed to fetch current block height after ${maxRetries} attempts.`);
+                
+                // Check if we are in an interactive environment
+                if (process.stdout.isTTY) {
+                    const response = await prompts({
+                        type: 'number',
+                        name: 'height',
+                        message: 'Hiro API is unreachable. Please enter the current Stacks block height manually (check explorer.hiro.so):',
+                        validate: value => value > 0 || 'Block height must be a positive number'
+                    });
+
+                    if (response.height) {
+                        return response.height;
+                    }
+                }
+
+                throw new Error('Network error: Hiro API unreachable and no manual override provided.');
+            }
+        }
+    }
+
+    throw new Error('Unexpected error in fetchCurrentBlockHeight');
+}

--- a/scripts/utils/block-height.ts
+++ b/scripts/utils/block-height.ts
@@ -6,7 +6,8 @@ import prompts from 'prompts';
 export async function fetchCurrentBlockHeight(
     network: 'mainnet' | 'testnet' | 'devnet' = 'mainnet',
     maxRetries: number = 3,
-    retryDelayMs: number = 2000
+    retryDelayMs: number = 2000,
+    timeoutMs: number = 5000
 ): Promise<number> {
     const apiUrl = network === 'mainnet'
         ? 'https://api.mainnet.hiro.so/v2/info'
@@ -16,7 +17,7 @@ export async function fetchCurrentBlockHeight(
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
         try {
-            const response = await fetch(apiUrl, { signal: AbortSignal.timeout(5000) });
+            const response = await fetch(apiUrl, { signal: AbortSignal.timeout(timeoutMs) });
 
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/scripts/utils/transaction-helpers.ts
+++ b/scripts/utils/transaction-helpers.ts
@@ -272,7 +272,7 @@ export class TransactionTracker {
         this.transactions.forEach((tx, index) => {
             console.log(`${index + 1}. ${tx.type}`);
             console.log(`   TX ID: ${tx.txid}`);
-            console.log(`   Time: ${tx.timestamp.toLocaleString()}`);
+            console.log(`   Time: ${tx.timestamp.toLocaleString()} (${tx.timestamp.toISOString()})`);
             console.log(`   Explorer: ${getExplorerTxUrl(tx.txid, network)}`);
             if (tx.details) {
                 console.log(`   Details: ${JSON.stringify(tx.details)}`);

--- a/scripts/utils/transaction-helpers.ts
+++ b/scripts/utils/transaction-helpers.ts
@@ -9,6 +9,7 @@ import fs from 'fs';
 import toml from 'toml';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { fetchCurrentBlockHeight } from './block-height.js';
 
 // ES module equivalents for __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -63,39 +64,7 @@ export async function getPrivateKey(): Promise<string> {
  * Get current Stacks block height from the network
  */
 export async function getCurrentBlockHeight(network: 'mainnet' | 'testnet' | 'devnet' = 'mainnet'): Promise<number> {
-    const apiUrl = network === 'mainnet'
-        ? 'https://api.mainnet.hiro.so/v2/info'
-        : network === 'testnet'
-            ? 'https://api.testnet.hiro.so/v2/info'
-            : 'http://localhost:3999/v2/info';
-
-    // Try multiple times with delays to avoid rate limiting
-    for (let attempt = 1; attempt <= 3; attempt++) {
-        try {
-            const response = await fetch(apiUrl);
-
-            if (!response.ok) {
-                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-            }
-
-            const data = await response.json();
-            return data.stacks_tip_height;
-        } catch (error) {
-            if (attempt < 3) {
-                console.warn(`Attempt ${attempt} failed, retrying in 2s...`);
-                await sleep(2000);
-            } else {
-                console.warn('⚠️  Could not fetch current block height after 3 attempts');
-                console.warn('   Using estimated fallback value');
-                // Updated fallback - approximate current mainnet height as of Jan 2026
-                // Stacks mainnet is at ~6,188,000 blocks
-                return 6188000;
-            }
-        }
-    }
-
-    // This should never be reached, but TypeScript needs it
-    return 6188000;
+    return fetchCurrentBlockHeight(network);
 }
 
 /**

--- a/scripts/utils/transaction-helpers.ts
+++ b/scripts/utils/transaction-helpers.ts
@@ -237,9 +237,19 @@ export interface TransactionSummary {
     details?: any;
 }
 
+/**
+ * Utility class to track and summarize contract transactions executed during a script run
+ */
 export class TransactionTracker {
+    /** Internal storage for transaction summaries */
     private transactions: TransactionSummary[] = [];
 
+    /**
+     * Add a new transaction to the tracker
+     * @param type The operation type (e.g., 'Market Creation')
+     * @param txid The transaction ID returned by the network
+     * @param details Optional additional data to log
+     */
     add(type: string, txid: string, details?: any): void {
         this.transactions.push({
             type,


### PR DESCRIPTION
Changes Implemented:
Centralized Block Height Utility: Created scripts/utils/block-height.ts to handle fetching the current Stacks block height. This utility includes:

Retry Logic: Automatically retries on API failure with configurable delays and timeouts.
Interactive Fallback: If the Hiro API is unreachable and the script is running in an interactive terminal, it prompts the user to manually enter the current block height (verifiable via explorer).
Robust Failure Mode: Throws a clear error if no manual override is provided in a non-interactive environment, preventing silent use of stale data.
Refactored Utility Helpers: Updated scripts/utils/transaction-helpers.ts to use the new centralized utility, ensuring consistent behavior across all scripts that import it.

Refactored Interaction Script: Updated scripts/interact-contract.ts to:

Remove redundant local getCurrentBlockHeight and hardcoded fallback.
Replace hardcoded END_BLOCK_HEIGHT and RESOLUTION_BLOCK_HEIGHT with dynamic offsets (END_BLOCK_OFFSET, RESOLUTION_BLOCK_OFFSET), calculating actual heights relative to the live chain tip.
Consolidated Governance and Trading Scripts: Refactored scripts/governance-operations.ts and scripts/multi-outcome-trading.ts to remove duplicate local fallback logic and import the robust implementation from the central utility.

Closes #58 
