### PR TITLE
Fix/missing alt attributes images

### DIFF
--- a/frontend/src/components/CacheDashboard.tsx
+++ b/frontend/src/components/CacheDashboard.tsx
@@ -49,9 +49,9 @@ export function CacheDashboard() {
       <button
         onClick={() => setIsOpen(true)}
         className="fixed bottom-4 right-4 p-3 bg-neutral-900 border border-neutral-800 rounded-lg shadow-lg hover:bg-neutral-800 transition-colors"
-        title="Cache Dashboard"
+        aria-label="Open cache dashboard"
       >
-        <svg className="w-5 h-5 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-5 h-5 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
         </svg>
       </button>
@@ -65,8 +65,9 @@ export function CacheDashboard() {
         <button
           onClick={() => setIsOpen(false)}
           className="text-neutral-500 hover:text-white"
+          aria-label="Close cache dashboard"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
           </svg>
         </button>

--- a/frontend/src/components/DisputeCard.tsx
+++ b/frontend/src/components/DisputeCard.tsx
@@ -72,6 +72,7 @@ export function DisputeCard({
               fill="none" 
               viewBox="0 0 24 24" 
               stroke="currentColor"
+              aria-hidden="true"
             >
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
             </svg>
@@ -222,7 +223,7 @@ export function EmptyDisputeState() {
   return (
     <div className="text-center py-12 bg-gray-800/30 rounded-xl border border-gray-700">
       <div className="w-16 h-16 bg-gray-700/50 rounded-full flex items-center justify-center mx-auto mb-4">
-        <svg className="w-8 h-8 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg className="w-8 h-8 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
       </div>

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -93,6 +93,7 @@ export class ErrorBoundary extends Component<Props, State> {
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden="true"
               >
                 <path
                   strokeLinecap="round"

--- a/frontend/src/components/ErrorDisplay.tsx
+++ b/frontend/src/components/ErrorDisplay.tsx
@@ -27,7 +27,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
       case ErrorCode.NETWORK_ERROR:
       case ErrorCode.TIMEOUT_ERROR:
         return (
-          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
             <path
               fillRule="evenodd"
               d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
@@ -38,7 +38,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
       case ErrorCode.UNAUTHORIZED:
       case ErrorCode.FORBIDDEN:
         return (
-          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
             <path
               fillRule="evenodd"
               d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z"
@@ -48,7 +48,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
         );
       default:
         return (
-          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
             <path
               fillRule="evenodd"
               d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
@@ -135,7 +135,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
             className="ml-auto flex-shrink-0 inline-flex rounded-md p-1.5 hover:bg-black hover:bg-opacity-10 focus:outline-none"
           >
             <span className="sr-only">Dismiss</span>
-            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
               <path
                 fillRule="evenodd"
                 d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"

--- a/frontend/src/components/ErrorMessage.tsx
+++ b/frontend/src/components/ErrorMessage.tsx
@@ -28,7 +28,7 @@ export function ErrorMessage({
       <div className={`w-full p-4 bg-red-500/10 border-y border-red-500/20 ${className}`}>
         <div className="container flex items-center justify-between gap-4">
           <div className="flex items-center gap-3">
-            <svg className="w-5 h-5 text-red-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-5 h-5 text-red-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             <p className="text-red-400 text-sm">{message}</p>
@@ -39,7 +39,7 @@ export function ErrorMessage({
               className="text-red-400 hover:text-red-300 transition-colors"
               aria-label="Dismiss error"
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
@@ -53,7 +53,7 @@ export function ErrorMessage({
     return (
       <div className={`fixed bottom-4 right-4 max-w-sm p-4 rounded-lg bg-red-500/10 border border-red-500/20 shadow-lg z-50 ${className}`}>
         <div className="flex items-start gap-3">
-          <svg className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           <div className="flex-1">
@@ -65,7 +65,7 @@ export function ErrorMessage({
               className="text-red-400 hover:text-red-300 transition-colors"
               aria-label="Dismiss error"
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
@@ -79,7 +79,7 @@ export function ErrorMessage({
   return (
     <div className={`p-4 rounded-xl bg-red-500/10 border border-red-500/20 ${className}`}>
       <div className="flex items-start gap-3">
-        <svg className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
         <div className="flex-1">
@@ -91,7 +91,7 @@ export function ErrorMessage({
             className="text-red-400 hover:text-red-300 transition-colors"
             aria-label="Dismiss error"
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>

--- a/frontend/src/components/ExportDialog.tsx
+++ b/frontend/src/components/ExportDialog.tsx
@@ -161,7 +161,7 @@ export default function ExportDialog({
           {step === 'complete' && (
             <div className="text-center">
               <div className="mb-4">
-                <svg className="w-12 h-12 text-green-500 mx-auto" fill="currentColor" viewBox="0 0 20 20">
+                <svg className="w-12 h-12 text-green-500 mx-auto" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                   <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                 </svg>
               </div>
@@ -179,7 +179,7 @@ export default function ExportDialog({
           {step === 'error' && (
             <div className="text-center">
               <div className="mb-4">
-                <svg className="w-12 h-12 text-red-500 mx-auto" fill="currentColor" viewBox="0 0 20 20">
+                <svg className="w-12 h-12 text-red-500 mx-auto" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                   <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
                 </svg>
               </div>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -17,13 +17,13 @@ export function Footer() {
               Decentralized prediction markets built on Bitcoin through Stacks.
             </p>
             <div className="flex items-center gap-4 mt-6">
-              <a href="https://twitter.com/0xCast" target="_blank" rel="noopener noreferrer" className="text-neutral-600 dark:text-neutral-500 hover:text-black dark:hover:text-white transition-colors">
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+              <a href="https://twitter.com/0xCast" target="_blank" rel="noopener noreferrer" className="text-neutral-600 dark:text-neutral-500 hover:text-black dark:hover:text-white transition-colors" aria-label="0xCast on Twitter">
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
                 </svg>
               </a>
-              <a href="https://github.com/0xCast" target="_blank" rel="noopener noreferrer" className="text-neutral-600 dark:text-neutral-500 hover:text-black dark:hover:text-white transition-colors">
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+              <a href="https://github.com/0xCast" target="_blank" rel="noopener noreferrer" className="text-neutral-600 dark:text-neutral-500 hover:text-black dark:hover:text-white transition-colors" aria-label="0xCast on GitHub">
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
                 </svg>
               </a>
@@ -59,7 +59,7 @@ export function Footer() {
           <p className="text-neutral-600 dark:text-neutral-600 text-sm">© 2026 0xCast. All rights reserved.</p>
           <div className="flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-600">
             <span>Secured by</span>
-            <svg className="w-4 h-4 text-orange-500" fill="currentColor" viewBox="0 0 24 24">
+            <svg className="w-4 h-4 text-orange-500" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path d="M23.638 14.904c-1.602 6.43-8.113 10.34-14.542 8.736C2.67 22.05-1.244 15.525.362 9.105 1.962 2.67 8.475-1.243 14.9.358c6.43 1.605 10.342 8.115 8.738 14.546z" />
             </svg>
             <span>Bitcoin</span>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -104,13 +104,15 @@ export function Header() {
             <button
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
               className="md:hidden p-2 text-neutral-600 dark:text-neutral-400 hover:text-black dark:hover:text-white"
+              aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
+              aria-expanded={mobileMenuOpen}
             >
               {mobileMenuOpen ? (
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                 </svg>
               ) : (
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
                 </svg>
               )}

--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -73,6 +73,7 @@ export function LanguageSwitcher() {
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
+          aria-hidden="true"
         >
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
@@ -106,6 +107,7 @@ export function LanguageSwitcher() {
                     className="ml-auto w-4 h-4"
                     fill="currentColor"
                     viewBox="0 0 20 20"
+                    aria-hidden="true"
                   >
                     <path
                       fillRule="evenodd"

--- a/frontend/src/components/LiquidityMiningPage.tsx
+++ b/frontend/src/components/LiquidityMiningPage.tsx
@@ -125,6 +125,7 @@ export const LiquidityMiningPage: React.FC<LiquidityMiningPageProps> = ({
               className="w-5 h-5 mr-2 flex-shrink-0 mt-0.5"
               fill="currentColor"
               viewBox="0 0 20 20"
+              aria-hidden="true"
             >
               <path
                 fillRule="evenodd"
@@ -139,6 +140,7 @@ export const LiquidityMiningPage: React.FC<LiquidityMiningPageProps> = ({
               className="w-5 h-5 mr-2 flex-shrink-0 mt-0.5"
               fill="currentColor"
               viewBox="0 0 20 20"
+              aria-hidden="true"
             >
               <path
                 fillRule="evenodd"
@@ -153,6 +155,7 @@ export const LiquidityMiningPage: React.FC<LiquidityMiningPageProps> = ({
               className="w-5 h-5 mr-2 flex-shrink-0 mt-0.5"
               fill="currentColor"
               viewBox="0 0 20 20"
+              aria-hidden="true"
             >
               <path
                 fillRule="evenodd"
@@ -167,6 +170,7 @@ export const LiquidityMiningPage: React.FC<LiquidityMiningPageProps> = ({
               className="w-5 h-5 mr-2 flex-shrink-0 mt-0.5"
               fill="currentColor"
               viewBox="0 0 20 20"
+              aria-hidden="true"
             >
               <path
                 fillRule="evenodd"

--- a/frontend/src/components/LiquidityStats.tsx
+++ b/frontend/src/components/LiquidityStats.tsx
@@ -150,7 +150,7 @@ export function LiquidityStats({ pools, positions, pendingRewards }: LiquiditySt
           label="Active Pools"
           value={pools.filter(p => p.stxBalance > 0n).length.toString()}
           icon={
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
             </svg>
           }
@@ -159,7 +159,7 @@ export function LiquidityStats({ pools, positions, pendingRewards }: LiquiditySt
           label="Your Positions"
           value={positions.length.toString()}
           icon={
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
             </svg>
           }
@@ -168,7 +168,7 @@ export function LiquidityStats({ pools, positions, pendingRewards }: LiquiditySt
           label="LP Share"
           value={positions.length > 0 && totalTVL > 0n ? `${(Number((userTVL * 10000n) / totalTVL) / 100).toFixed(2)}%` : '0%'}
           icon={
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z" />
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z" />
             </svg>

--- a/frontend/src/components/Loading.tsx
+++ b/frontend/src/components/Loading.tsx
@@ -17,6 +17,7 @@ export function LoadingSpinner({ size = 'md', className = '' }: LoadingSpinnerPr
         viewBox="0 0 24 24"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
       >
         <circle
           className="opacity-25"
@@ -38,7 +39,7 @@ export function LoadingSpinner({ size = 'md', className = '' }: LoadingSpinnerPr
 
 export function LoadingState({ message = 'Loading...' }: { message?: string }) {
   return (
-    <div className="flex flex-col items-center justify-center py-20">
+    <div className="flex flex-col items-center justify-center py-20" role="status">
       <LoadingSpinner size="lg" className="text-blue-500" />
       <p className="mt-4 text-zinc-500">{message}</p>
     </div>

--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -13,7 +13,7 @@ export function Logo({ className = '', size = 'md' }: LogoProps) {
   return (
     <div className={`flex items-center gap-3 ${className}`}>
       <div className={`${sizes[size]} relative`}>
-        <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-full">
+        <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-full" role="img" aria-label="0xCast logo">
           <defs>
             <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
               <stop offset="0%" style={{ stopColor: '#0a0a0a', stopOpacity: 1 }} />

--- a/frontend/src/components/MarketCard.tsx
+++ b/frontend/src/components/MarketCard.tsx
@@ -54,6 +54,7 @@ export function MarketCard({ market, showCategory = true }: MarketCardProps) {
             fill={watched ? 'currentColor' : 'none'}
             stroke="currentColor"
             viewBox="0 0 24 24"
+            aria-hidden="true"
           >
             <path
               strokeLinecap="round"

--- a/frontend/src/components/MarketFilter.tsx
+++ b/frontend/src/components/MarketFilter.tsx
@@ -241,7 +241,7 @@ export function MarketFilter({
               justifyContent: 'center',
             }}
           >
-            <svg style={{ width: '16px', height: '16px' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg style={{ width: '16px', height: '16px' }} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
@@ -280,7 +280,7 @@ export function MarketFilter({
         >
           <span>{selectedCategoryConfig.icon}</span>
           <span>{selectedCategoryConfig.label}</span>
-          <svg style={chevronStyle} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg style={chevronStyle} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
           </svg>
         </button>
@@ -319,11 +319,11 @@ export function MarketFilter({
           aria-haspopup="listbox"
           aria-expanded={showSortDropdown}
         >
-          <svg style={{ width: '16px', height: '16px' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg style={{ width: '16px', height: '16px' }} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12" />
           </svg>
           <span>{selectedSortConfig.label}</span>
-          <svg style={chevronStyle} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg style={chevronStyle} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
           </svg>
         </button>
@@ -359,7 +359,7 @@ export function MarketFilter({
         }}
         onClick={() => setShowAdvanced(!showAdvanced)}
       >
-        <svg style={{ width: '16px', height: '16px' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg style={{ width: '16px', height: '16px' }} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
         </svg>
         <span>Advanced</span>
@@ -390,7 +390,7 @@ export function MarketFilter({
           }}
           onClick={onSavePreset}
         >
-          <svg style={{ width: '16px', height: '16px' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg style={{ width: '16px', height: '16px' }} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
           </svg>
           <span>Save Preset</span>
@@ -408,7 +408,7 @@ export function MarketFilter({
         }}
         onClick={() => onOnlyWatchlistChange(!selectedOnlyWatchlist)}
       >
-        <svg style={{ width: '16px', height: '16px' }} fill={selectedOnlyWatchlist ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
+        <svg style={{ width: '16px', height: '16px' }} fill={selectedOnlyWatchlist ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
         </svg>
         <span>Watchlist</span>

--- a/frontend/src/components/MobileBottomNav.tsx
+++ b/frontend/src/components/MobileBottomNav.tsx
@@ -14,7 +14,7 @@ export function MobileBottomNav() {
       path: '/',
       label: 'Home',
       icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
         </svg>
       ),
@@ -23,7 +23,7 @@ export function MobileBottomNav() {
       path: '/markets',
       label: 'Markets',
       icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
         </svg>
       ),
@@ -32,7 +32,7 @@ export function MobileBottomNav() {
       path: '/create-market',
       label: 'Create',
       icon: (
-        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
         </svg>
       ),
@@ -41,7 +41,7 @@ export function MobileBottomNav() {
       path: '/analytics',
       label: 'Analytics',
       icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
         </svg>
       ),
@@ -50,7 +50,7 @@ export function MobileBottomNav() {
       path: '/portfolio',
       label: 'Portfolio',
       icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
         </svg>
       ),
@@ -59,7 +59,7 @@ export function MobileBottomNav() {
       path: '/watchlist',
       label: 'Watchlist',
       icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.645 20.91l-1.157-1.051C5.696 15.855 2.5 12.968 2.5 9.4 2.5 6.51 4.73 4.25 7.5 4.25c1.56 0 3.042.75 3.966 1.94A5.13 5.13 0 0 1 15.5 4.25c2.77 0 5 2.26 5 5.15 0 3.568-3.196 6.455-7.988 10.459l-0.867 0.718z" />
         </svg>
       ),
@@ -68,7 +68,7 @@ export function MobileBottomNav() {
       path: '/recently-viewed',
       label: 'Recent',
       icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m4-3a7 7 0 11-14 0 7 7 0 0114 0z" />
         </svg>
       ),
@@ -77,7 +77,7 @@ export function MobileBottomNav() {
       path: '/multi-markets',
       label: 'Multi',
       icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h13M8 12h13M8 17h13M3 7h.01M3 12h.01M3 17h.01" />
         </svg>
       ),

--- a/frontend/src/components/MobileBottomSheet.tsx
+++ b/frontend/src/components/MobileBottomSheet.tsx
@@ -58,8 +58,9 @@ export function MobileBottomSheet({
               <button
                 onClick={onClose}
                 className="p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+                aria-label="Close"
               >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>

--- a/frontend/src/components/MobileButton.tsx
+++ b/frontend/src/components/MobileButton.tsx
@@ -55,6 +55,7 @@ export function MobileButton({
           className="animate-spin h-5 w-5"
           fill="none"
           viewBox="0 0 24 24"
+          aria-hidden="true"
         >
           <circle
             className="opacity-25"

--- a/frontend/src/components/MobileModal.tsx
+++ b/frontend/src/components/MobileModal.tsx
@@ -72,7 +72,7 @@ export function MobileModal({
               className="p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors tap-target"
               aria-label="Close modal"
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>

--- a/frontend/src/components/MobileSelect.tsx
+++ b/frontend/src/components/MobileSelect.tsx
@@ -51,7 +51,7 @@ export const MobileSelect = forwardRef<HTMLSelectElement, MobileSelectProps>(
             ))}
           </select>
           <div className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-neutral-500">
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
             </svg>
           </div>

--- a/frontend/src/components/NetworkSelector.tsx
+++ b/frontend/src/components/NetworkSelector.tsx
@@ -96,6 +96,7 @@ export function NetworkSelector({ variant = 'dropdown', showLabel = true }: Netw
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
+          aria-hidden="true"
         >
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
@@ -137,7 +138,7 @@ export function NetworkSelector({ variant = 'dropdown', showLabel = true }: Netw
                   <p className="text-xs text-neutral-600 dark:text-neutral-500 truncate">{config.apiUrl}</p>
                 </div>
                 {isSelected && (
-                  <svg className="w-4 h-4 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+                  <svg className="w-4 h-4 text-green-500" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                     <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
                   </svg>
                 )}

--- a/frontend/src/components/NetworkSwitchDialog.tsx
+++ b/frontend/src/components/NetworkSwitchDialog.tsx
@@ -54,8 +54,9 @@ export function NetworkSwitchDialog({
           <button 
             onClick={onCancel}
             className="text-neutral-500 hover:text-white transition-colors"
+            aria-label="Close"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
@@ -71,7 +72,7 @@ export function NetworkSwitchDialog({
             </span>
           </div>
           
-          <svg className="w-6 h-6 text-neutral-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-6 h-6 text-neutral-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
           </svg>
           

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -19,13 +19,15 @@ export default function NotificationBell({
       <button
         onClick={() => setShowCenter(!showCenter)}
         className={`relative p-2 text-gray-600 hover:text-gray-900 transition ${className}`}
-        title="Notifications"
+        aria-label="Notifications"
+        aria-expanded={showCenter}
       >
         <svg
           className="w-6 h-6"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
+          aria-hidden="true"
         >
           <path
             strokeLinecap="round"

--- a/frontend/src/components/NotificationToast.tsx
+++ b/frontend/src/components/NotificationToast.tsx
@@ -77,7 +77,7 @@ export const NotificationToast: React.FC<NotificationToastProps> = ({ notificati
           className={`flex-shrink-0 ml-3 p-1 rounded ${closeButtonColor} transition-colors`}
           aria-label="Close notification"
         >
-          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
             <path
               fillRule="evenodd"
               d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"

--- a/frontend/src/components/OracleCard.tsx
+++ b/frontend/src/components/OracleCard.tsx
@@ -56,7 +56,7 @@ export function OracleCard({ oracle, onSelect, compact = false }: OracleCardProp
           <div className={`w-10 h-10 rounded-full flex items-center justify-center ${
             oracle.isRegistered ? 'bg-purple-500/20' : 'bg-gray-700'
           }`}>
-            <svg className={`w-5 h-5 ${oracle.isRegistered ? 'text-purple-400' : 'text-gray-500'}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className={`w-5 h-5 ${oracle.isRegistered ? 'text-purple-400' : 'text-gray-500'}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
             </svg>

--- a/frontend/src/components/OracleNetworkDashboard.tsx
+++ b/frontend/src/components/OracleNetworkDashboard.tsx
@@ -215,8 +215,9 @@ export const OracleNetworkDashboard: React.FC<OracleNetworkDashboardProps> = ({ 
               <button
                 onClick={() => setSelectedProvider(null)}
                 className="text-gray-400 hover:text-gray-600"
+                aria-label="Close provider details"
               >
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>

--- a/frontend/src/components/PageErrorBoundary.tsx
+++ b/frontend/src/components/PageErrorBoundary.tsx
@@ -48,7 +48,7 @@ export class PageErrorBoundary extends Component<PageErrorBoundaryProps, PageErr
         <div className="pt-[72px] min-h-screen flex items-center justify-center p-4">
           <div className="max-w-md w-full text-center">
             <div className="w-16 h-16 mx-auto mb-6 rounded-full bg-amber-500/10 flex items-center justify-center">
-              <svg className="w-8 h-8 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-8 h-8 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
               </svg>
             </div>

--- a/frontend/src/components/PerformanceDashboard.tsx
+++ b/frontend/src/components/PerformanceDashboard.tsx
@@ -29,8 +29,9 @@ export function PerformanceDashboard() {
         <button
           onClick={() => setIsVisible(false)}
           className="text-neutral-500 hover:text-white"
+          aria-label="Close performance dashboard"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
           </svg>
         </button>
@@ -89,9 +90,9 @@ export function PerformanceDashboardToggle() {
       <button
         onClick={() => setIsVisible(!isVisible)}
         className="fixed top-20 right-4 p-2 bg-neutral-900 border border-neutral-800 rounded-lg shadow-lg hover:bg-neutral-800 transition-colors"
-        title="Performance Dashboard"
+        aria-label="Toggle performance dashboard"
       >
-        <svg className="w-4 h-4 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-4 h-4 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
         </svg>
       </button>

--- a/frontend/src/components/PersonalStatsCard.tsx
+++ b/frontend/src/components/PersonalStatsCard.tsx
@@ -18,7 +18,7 @@ export function PersonalStatsCard({ stats, isConnected }: PersonalStatsCardProps
         <h3 className="text-lg font-semibold text-black dark:text-white mb-4">Your Performance</h3>
         <div className="flex flex-col items-center justify-center py-8 text-center">
           <div className="w-16 h-16 bg-neutral-300 dark:bg-neutral-800 rounded-full flex items-center justify-center mb-4">
-            <svg className="w-8 h-8 text-neutral-600 dark:text-neutral-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-8 h-8 text-neutral-600 dark:text-neutral-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
             </svg>
           </div>

--- a/frontend/src/components/PoolPositionRow.tsx
+++ b/frontend/src/components/PoolPositionRow.tsx
@@ -139,7 +139,7 @@ export function NoPositionsMessage() {
   return (
     <div className="text-center py-12 px-4 bg-neutral-100 dark:bg-neutral-900/30 rounded-xl border border-neutral-300 dark:border-neutral-800/50">
       <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-neutral-300 dark:bg-neutral-800/50 flex items-center justify-center">
-        <svg className="w-8 h-8 text-neutral-600 dark:text-neutral-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg className="w-8 h-8 text-neutral-600 dark:text-neutral-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
         </svg>
       </div>
@@ -151,7 +151,7 @@ export function NoPositionsMessage() {
         to="/liquidity"
         className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
       >
-        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
         </svg>
         Add Liquidity

--- a/frontend/src/components/RateLimitNotification.tsx
+++ b/frontend/src/components/RateLimitNotification.tsx
@@ -61,6 +61,7 @@ export const RateLimitNotification: React.FC<RateLimitNotificationProps> = ({
             className="w-5 h-5"
             fill="currentColor"
             viewBox="0 0 20 20"
+            aria-hidden="true"
           >
             <path
               fillRule="evenodd"
@@ -95,6 +96,7 @@ export const RateLimitNotification: React.FC<RateLimitNotificationProps> = ({
                 className="w-5 h-5"
                 fill="currentColor"
                 viewBox="0 0 20 20"
+                aria-hidden="true"
               >
                 <path
                   fillRule="evenodd"

--- a/frontend/src/components/ResolutionCard.tsx
+++ b/frontend/src/components/ResolutionCard.tsx
@@ -70,11 +70,11 @@ export function ResolutionCard({
           </div>
           <div className={`w-12 h-12 rounded-full ${resultBg} flex items-center justify-center`}>
             {resolution.result === 1 ? (
-              <svg className="w-6 h-6 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className="w-6 h-6 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
               </svg>
             ) : (
-              <svg className="w-6 h-6 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className="w-6 h-6 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             )}
@@ -189,7 +189,7 @@ export function EmptyResolutionState() {
   return (
     <div className="text-center py-12 bg-gray-800/30 rounded-xl border border-gray-700">
       <div className="w-16 h-16 bg-gray-700/50 rounded-full flex items-center justify-center mx-auto mb-4">
-        <svg className="w-8 h-8 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg className="w-8 h-8 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
         </svg>
       </div>

--- a/frontend/src/components/RewardNotification.tsx
+++ b/frontend/src/components/RewardNotification.tsx
@@ -42,6 +42,7 @@ export const RewardNotification: React.FC<RewardNotificationProps> = ({
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
+            aria-hidden="true"
           >
             <path
               strokeLinecap="round"
@@ -64,12 +65,14 @@ export const RewardNotification: React.FC<RewardNotificationProps> = ({
               onDismiss();
             }}
             className="flex-shrink-0 text-white hover:text-gray-200"
+            aria-label="Dismiss notification"
           >
             <svg
               className="w-5 h-5"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              aria-hidden="true"
             >
               <path
                 strokeLinecap="round"

--- a/frontend/src/components/ShareModal.tsx
+++ b/frontend/src/components/ShareModal.tsx
@@ -75,7 +75,7 @@ export function ShareModal({
             className="p-1 hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-lg transition-colors"
             aria-label="Close"
           >
-            <svg className="w-6 h-6 text-neutral-600 dark:text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-6 h-6 text-neutral-600 dark:text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
@@ -114,7 +114,7 @@ export function ShareModal({
                 onClick={shareToTwitter}
                 className="flex items-center justify-center gap-2 px-4 py-2 bg-blue-400 hover:bg-blue-500 text-white rounded-lg font-medium transition-colors"
               >
-                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
                 </svg>
                 Twitter
@@ -124,7 +124,7 @@ export function ShareModal({
                 onClick={shareToDiscord}
                 className="flex items-center justify-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg font-medium transition-colors"
               >
-                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515a.074.074 0 00-.079.037c-.211.375-.444.865-.607 1.25a18.27 18.27 0 00-5.487 0c-.163-.385-.396-.875-.607-1.25a.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.08.08 0 00.087-.027c.461-.63.873-1.295 1.226-1.994a.076.076 0 00-.042-.106c-.645-.245-1.26-.561-1.844-.906a.077.077 0 00-.009-.128c.124-.093.248-.189.368-.288a.076.076 0 00.084-.01c3.852 1.755 8.018 1.755 11.829 0a.077.077 0 00.083.01c.12.099.244.195.369.288a.077.077 0 00-.008.129c-.585.345-1.198.66-1.843.906a.077.077 0 00-.041.107c.359.719.77 1.364 1.226 1.994a.076.076 0 00.084.028c2.243-.613 4.438-1.587 5.994-3.03a.076.076 0 00.03-.057c.5-4.718-.838-8.812-3.543-12.46a.061.061 0 00-.031-.03zM8.02 15.33c-1.183 0-2.157-.965-2.157-2.156c0-1.193.964-2.157 2.157-2.157c1.193 0 2.156.964 2.156 2.157c0 1.191-.963 2.156-2.156 2.156zm7.975 0c-1.183 0-2.157-.965-2.157-2.156c0-1.193.964-2.157 2.157-2.157c1.193 0 2.157.964 2.157 2.157c0 1.191-.964 2.156-2.157 2.156z" />
                 </svg>
                 Discord
@@ -134,7 +134,7 @@ export function ShareModal({
                 onClick={shareToTelegram}
                 className="flex items-center justify-center gap-2 px-4 py-2 bg-sky-500 hover:bg-sky-600 text-white rounded-lg font-medium transition-colors"
               >
-                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a11.955 11.955 0 0 0-.064 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.155.339-.315.612-.495 4.563-3.173 6.071-4.209 7.377-5.427.566-.502 1.06-.886 1.493-1.169.42-.276.922-.42 1.466-.42z" />
                 </svg>
                 Telegram
@@ -144,7 +144,7 @@ export function ShareModal({
                 onClick={shareToReddit}
                 className="flex items-center justify-center gap-2 px-4 py-2 bg-orange-600 hover:bg-orange-700 text-white rounded-lg font-medium transition-colors"
               >
-                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.385 4.859-7.181 4.859-3.796 0-7.182-2.165-7.182-4.859a3.5 3.5 0 0 1 .476-1.84c-.424-.355-.641-.89-.641-1.427 0-.968.786-1.754 1.754-1.754.418 0 .801.134 1.122.357 1.191-.857 2.844-1.416 4.665-1.489l.812-3.827c.207-.026.426-.026.607 0l2.94.625c.321-.586.922-.961 1.6-.961z" />
                 </svg>
                 Reddit

--- a/frontend/src/components/SocialButtons.tsx
+++ b/frontend/src/components/SocialButtons.tsx
@@ -35,13 +35,14 @@ export function SocialButtons({
       <button
         onClick={() => setShowShareModal(true)}
         className={baseClasses[variant]}
-        title="Share this market"
+        aria-label="Share this market"
       >
         <svg
           className={variant === 'icon' ? iconClasses : 'w-4 h-4'}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
+          aria-hidden="true"
         >
           <path
             strokeLinecap="round"

--- a/frontend/src/components/TestnetWarningBanner.tsx
+++ b/frontend/src/components/TestnetWarningBanner.tsx
@@ -54,7 +54,7 @@ export function TestnetWarningBanner({
               className="text-yellow-500/70 hover:text-yellow-500 p-1 transition-colors"
               aria-label="Dismiss warning"
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>

--- a/frontend/src/components/ThemeSwitcher.tsx
+++ b/frontend/src/components/ThemeSwitcher.tsx
@@ -23,14 +23,14 @@ export function ThemeSwitcher({ variant = 'icon', className = '' }: ThemeSwitche
       >
         {theme === 'light' ? (
           <>
-            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
               <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
             </svg>
             <span>Dark</span>
           </>
         ) : (
           <>
-            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
               <path fillRule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.536l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.121-10.607a1 1 0 010 1.414l-.707.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.464 5.05l-.707-.707a1 1 0 00-1.414 1.414l.707.707zm5.657 9.193l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zM5 11a1 1 0 100-2H4a1 1 0 100 2h1z" clipRule="evenodd" />
             </svg>
             <span>Light</span>
@@ -48,11 +48,11 @@ export function ThemeSwitcher({ variant = 'icon', className = '' }: ThemeSwitche
       aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} theme`}
     >
       {theme === 'light' ? (
-        <svg className="w-5 h-5 text-neutral-600 dark:text-neutral-400" fill="currentColor" viewBox="0 0 20 20">
+        <svg className="w-5 h-5 text-neutral-600 dark:text-neutral-400" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
           <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
         </svg>
       ) : (
-        <svg className="w-5 h-5 text-neutral-400" fill="currentColor" viewBox="0 0 20 20">
+        <svg className="w-5 h-5 text-neutral-400" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
           <path fillRule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.536l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.121-10.607a1 1 0 010 1.414l-.707.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.464 5.05l-.707-.707a1 1 0 00-1.414 1.414l.707.707zm5.657 9.193l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zM5 11a1 1 0 100-2H4a1 1 0 100 2h1z" clipRule="evenodd" />
             </svg>
       )}

--- a/frontend/src/components/TransactionToast.tsx
+++ b/frontend/src/components/TransactionToast.tsx
@@ -54,20 +54,20 @@ export function TransactionToast({
       case TransactionStatus.PENDING:
         return (
           <div style={spinnerStyle}>
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
             </svg>
           </div>
         );
       case TransactionStatus.SUCCESS:
         return (
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#22C55E">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#22C55E" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
           </svg>
         );
       case TransactionStatus.FAILED:
         return (
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#EF4444">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#EF4444" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
           </svg>
         );
@@ -164,8 +164,8 @@ export function TransactionToast({
             {getIcon()}
             <span style={titleStyle}>{formatTransactionType(transaction.type)}</span>
           </div>
-          <button style={closeButtonStyle} onClick={handleDismiss}>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <button style={closeButtonStyle} onClick={handleDismiss} aria-label="Dismiss">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
@@ -186,7 +186,7 @@ export function TransactionToast({
           style={linkStyle}
         >
           View on Explorer
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
           </svg>
         </a>

--- a/frontend/src/components/examples/AccessibleDropdownExample.tsx
+++ b/frontend/src/components/examples/AccessibleDropdownExample.tsx
@@ -51,6 +51,7 @@ export function AccessibleDropdownExample({
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
+          aria-hidden="true"
         >
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
@@ -82,6 +83,7 @@ export function AccessibleDropdownExample({
                       className="w-4 h-4"
                       fill="currentColor"
                       viewBox="0 0 20 20"
+                      aria-hidden="true"
                     >
                       <path
                         fillRule="evenodd"

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -51,9 +51,9 @@ export function AnalyticsPage() {
             <button 
               onClick={refresh}
               className="p-2 text-neutral-400 hover:text-white bg-neutral-900 border border-neutral-800 rounded-lg transition-colors"
-              title="Refresh data"
+              aria-label="Refresh data"
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
               </svg>
             </button>
@@ -74,7 +74,7 @@ export function AnalyticsPage() {
                   subtitle={`${platformStats?.activeMarkets || 0} active`}
                   color="blue"
                   icon={
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
                     </svg>
                   }
@@ -85,7 +85,7 @@ export function AnalyticsPage() {
                   subtitle="All time"
                   color="green"
                   icon={
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
                   }
@@ -96,7 +96,7 @@ export function AnalyticsPage() {
                   subtitle={`~${platformStats?.totalUsers || 0} users`}
                   color="purple"
                   icon={
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
                     </svg>
                   }
@@ -107,7 +107,7 @@ export function AnalyticsPage() {
                   subtitle="2% protocol fee"
                   color="amber"
                   icon={
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z" />
                     </svg>
                   }

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -199,6 +199,7 @@ export function LeaderboardPage() {
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              aria-hidden="true"
             >
               <path
                 strokeLinecap="round"

--- a/frontend/src/pages/LiquidityPage.tsx
+++ b/frontend/src/pages/LiquidityPage.tsx
@@ -80,7 +80,7 @@ export function LiquidityPage() {
         <div className="max-w-2xl mx-auto text-center">
           <div className="bg-gray-800/50 rounded-xl p-8 border border-gray-700">
             <div className="w-16 h-16 bg-blue-500/20 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg className="w-8 h-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className="w-8 h-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z" />
               </svg>
             </div>
@@ -273,7 +273,7 @@ function PoolsTab({ pools, positions, rewards, onAddLiquidity, onRemoveLiquidity
     return (
       <div className="text-center py-12 bg-gray-800/30 rounded-xl border border-gray-700">
         <div className="w-16 h-16 bg-gray-700/50 rounded-full flex items-center justify-center mx-auto mb-4">
-          <svg className="w-8 h-8 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg className="w-8 h-8 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
           </svg>
         </div>
@@ -322,7 +322,7 @@ function PositionsTab({ positions, pools, rewards, onRemoveLiquidity, onClaimRew
     return (
       <div className="text-center py-12 bg-gray-800/30 rounded-xl border border-gray-700">
         <div className="w-16 h-16 bg-gray-700/50 rounded-full flex items-center justify-center mx-auto mb-4">
-          <svg className="w-8 h-8 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg className="w-8 h-8 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
           </svg>
         </div>
@@ -412,7 +412,7 @@ function RewardsTab({ rewards, onClaimRewards, isClaiming }: RewardsTabProps) {
     return (
       <div className="text-center py-12 bg-gray-800/30 rounded-xl border border-gray-700">
         <div className="w-16 h-16 bg-gray-700/50 rounded-full flex items-center justify-center mx-auto mb-4">
-          <svg className="w-8 h-8 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg className="w-8 h-8 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
         </div>
@@ -494,8 +494,8 @@ function AddLiquidityModal({ pool, onClose, onSubmit, isSubmitting, error }: Add
       <div className="bg-gray-900 rounded-xl p-6 w-full max-w-md border border-gray-700">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-xl font-bold text-white">Add Liquidity</h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-white">
-            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <button onClick={onClose} className="text-gray-400 hover:text-white" aria-label="Close">
+            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
@@ -567,8 +567,8 @@ function RemoveLiquidityModal({ pool, position, onClose, onSubmit, isSubmitting,
       <div className="bg-gray-900 rounded-xl p-6 w-full max-w-md border border-gray-700">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-xl font-bold text-white">Remove Liquidity</h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-white">
-            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <button onClick={onClose} className="text-gray-400 hover:text-white" aria-label="Close">
+            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>

--- a/frontend/src/pages/MarketsPage.tsx
+++ b/frontend/src/pages/MarketsPage.tsx
@@ -181,6 +181,7 @@ export function MarketsPage() {
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              aria-hidden="true"
             >
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
             </svg>
@@ -265,8 +266,9 @@ export function MarketsPage() {
                       cursor: 'pointer',
                       marginRight: 4
                     }}
+                    aria-label={`Delete preset ${preset.name}`}
                   >
-                    <svg style={{ width: 12, height: 12 }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg style={{ width: 12, height: 12 }} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                     </svg>
                   </button>
@@ -321,6 +323,7 @@ export function MarketsPage() {
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden="true"
               >
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
               </svg>

--- a/frontend/src/pages/OraclePage.tsx
+++ b/frontend/src/pages/OraclePage.tsx
@@ -39,7 +39,7 @@ export function OraclePage() {
         <div className="max-w-2xl mx-auto text-center">
           <div className="bg-gray-800/50 rounded-xl p-8 border border-gray-700">
             <div className="w-16 h-16 bg-purple-500/20 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg className="w-8 h-8 text-purple-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className="w-8 h-8 text-purple-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
               </svg>
@@ -75,7 +75,7 @@ export function OraclePage() {
         <div className="mb-6 p-4 bg-purple-500/20 border border-purple-500/50 rounded-lg">
           <div className="flex items-center gap-3">
             <div className="w-10 h-10 bg-purple-500/30 rounded-full flex items-center justify-center">
-              <svg className="w-5 h-5 text-purple-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className="w-5 h-5 text-purple-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
             </div>
@@ -677,7 +677,7 @@ function AdminTab() {
       {/* Warning Banner */}
       <div className="p-4 bg-yellow-500/20 border border-yellow-500/50 rounded-lg">
         <div className="flex items-center gap-3">
-          <svg className="w-5 h-5 text-yellow-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg className="w-5 h-5 text-yellow-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
           </svg>
           <p className="text-yellow-400 text-sm">

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -139,7 +139,7 @@ export function PortfolioPage() {
       <div className="pt-[72px] min-h-screen flex items-center justify-center px-4">
         <div className="text-center max-w-md mx-auto">
           <div className="w-16 h-16 sm:w-20 sm:h-20 mx-auto mb-6 rounded-full bg-blue-500/10 flex items-center justify-center">
-            <svg className="w-8 h-8 sm:w-10 sm:h-10 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-8 h-8 sm:w-10 sm:h-10 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
             </svg>
           </div>
@@ -252,7 +252,7 @@ export function PortfolioPage() {
                           </div>
                         </div>
 
-                        <svg className="hidden sm:block w-5 h-5 text-neutral-600 flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg className="hidden sm:block w-5 h-5 text-neutral-600 flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                         </svg>
                       </div>
@@ -300,7 +300,7 @@ export function PortfolioPage() {
         ) : (
           <div className="card p-12 sm:p-16 lg:p-24 text-center">
             <div className="w-16 h-16 sm:w-20 sm:h-20 lg:w-24 lg:h-24 mx-auto mb-6 sm:mb-8 lg:mb-10 rounded-full bg-neutral-900 flex items-center justify-center">
-              <svg className="w-8 h-8 sm:w-10 sm:h-10 lg:w-12 lg:h-12 text-neutral-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-8 h-8 sm:w-10 sm:h-10 lg:w-12 lg:h-12 text-neutral-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
               </svg>
             </div>

--- a/frontend/src/pages/TradePage.tsx
+++ b/frontend/src/pages/TradePage.tsx
@@ -187,7 +187,7 @@ export function TradePage() {
       <div className="pt-[72px] min-h-screen flex items-center justify-center">
         <div className="text-center max-w-md mx-auto px-4">
           <div className="w-16 h-16 mx-auto mb-6 rounded-full bg-neutral-900 flex items-center justify-center">
-            <svg className="w-8 h-8 text-neutral-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-8 h-8 text-neutral-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
           </div>
@@ -214,7 +214,7 @@ export function TradePage() {
       <div className="container max-w-5xl py-8 sm:py-12 lg:py-16 px-4 sm:px-6">
         {/* Back */}
         <Link to="/markets" className="inline-flex items-center gap-2 text-neutral-500 hover:text-white mb-6 sm:mb-10 transition-colors text-sm sm:text-base">
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
           </svg>
           Back to Markets
@@ -267,7 +267,7 @@ export function TradePage() {
                   to={`/oracle?market=${marketId}`}
                   className="mt-4 inline-flex items-center gap-2 text-sm text-purple-400 hover:text-purple-300 transition-colors"
                 >
-                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                   </svg>
@@ -449,7 +449,7 @@ export function TradePage() {
                         className="inline-flex items-center gap-1 underline hover:no-underline"
                       >
                         View on Explorer
-                        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                         </svg>
                       </a>
@@ -493,7 +493,7 @@ export function TradePage() {
                   >
                     {isStaking ? (
                       <span className="flex items-center justify-center gap-2">
-                        <svg className="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24">
+                        <svg className="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                           <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                           <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                         </svg>


### PR DESCRIPTION
Decorative images — given aria-hidden="true" so screen readers skip them:

All icon SVGs inside buttons that already have aria-label (close buttons, theme toggle, menu toggle, notification bell, share button, etc.)
All illustrative/empty-state SVGs where adjacent heading or text conveys the meaning
All inline SVG icons inside links or list items where the surrounding text is the label
Icon-only interactive elements that were missing accessible names also got aria-label added:

Mobile menu toggle in Header.tsx
Close buttons in MobileBottomSheet, OracleNetworkDashboard, LiquidityPage modals
Preset delete button in MarketsPage
Refresh button in AnalyticsPage
Cache and performance dashboard toggles
Social links in Footer.tsx
Share button in SocialButtons.tsx
Notification bell in NotificationBell.tsx

Closes #159