### PR TITLE
replace static page imports with lazy loaded equivalents

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { WalletProvider } from './components/WalletProvider';
 import { TransactionProvider } from './components/TransactionProvider';
@@ -12,25 +12,27 @@ import { Header } from './components/Header';
 import { Footer } from './components/Footer';
 import { MobileBottomNav } from './components/MobileBottomNav';
 import { TestnetWarningBanner } from './components/TestnetWarningBanner';
-import { LandingPage } from './pages/LandingPage';
-import { MarketsPage } from './pages/MarketsPage';
-import { TradePage } from './pages/TradePage';
-import { PortfolioPage } from './pages/PortfolioPage';
-import { TokenPage } from './pages/TokenPage';
-import { StakingPage } from './pages/StakingPage';
-import { GovernancePage } from './pages/GovernancePage';
-import { TransactionHistoryPage } from './pages/TransactionHistoryPage';
-import { CreateMarketPage } from './pages/CreateMarketPage';
-import { OraclePage } from './pages/OraclePage';
-import { LiquidityPage } from './pages/LiquidityPage';
-import { AnalyticsPage } from './pages/AnalyticsPage';
-import { LeaderboardPage } from './pages/LeaderboardPage';
-import { MultiMarketsPage } from './pages/MultiMarketsPage';
-import { MultiTradePage } from './pages/MultiTradePage';
-import { CreateMultiMarketPage } from './pages/CreateMultiMarketPage';
-import { WatchlistPage } from './pages/WatchlistPage';
-import { RecentlyViewedPage } from './pages/RecentlyViewedPage';
+import { LoadingState } from './components/Loading';
 import { GDPRInitializer } from './utils/gdprInitializer';
+
+const LandingPage = lazy(() => import('./pages/LandingPage').then(m => ({ default: m.LandingPage })));
+const MarketsPage = lazy(() => import('./pages/MarketsPage').then(m => ({ default: m.MarketsPage })));
+const TradePage = lazy(() => import('./pages/TradePage').then(m => ({ default: m.TradePage })));
+const PortfolioPage = lazy(() => import('./pages/PortfolioPage').then(m => ({ default: m.PortfolioPage })));
+const WatchlistPage = lazy(() => import('./pages/WatchlistPage').then(m => ({ default: m.WatchlistPage })));
+const RecentlyViewedPage = lazy(() => import('./pages/RecentlyViewedPage').then(m => ({ default: m.RecentlyViewedPage })));
+const TokenPage = lazy(() => import('./pages/TokenPage').then(m => ({ default: m.TokenPage })));
+const StakingPage = lazy(() => import('./pages/StakingPage').then(m => ({ default: m.StakingPage })));
+const GovernancePage = lazy(() => import('./pages/GovernancePage').then(m => ({ default: m.GovernancePage })));
+const TransactionHistoryPage = lazy(() => import('./pages/TransactionHistoryPage').then(m => ({ default: m.TransactionHistoryPage })));
+const CreateMarketPage = lazy(() => import('./pages/CreateMarketPage').then(m => ({ default: m.CreateMarketPage })));
+const OraclePage = lazy(() => import('./pages/OraclePage').then(m => ({ default: m.OraclePage })));
+const LiquidityPage = lazy(() => import('./pages/LiquidityPage').then(m => ({ default: m.LiquidityPage })));
+const AnalyticsPage = lazy(() => import('./pages/AnalyticsPage').then(m => ({ default: m.AnalyticsPage })));
+const LeaderboardPage = lazy(() => import('./pages/LeaderboardPage').then(m => ({ default: m.LeaderboardPage })));
+const MultiMarketsPage = lazy(() => import('./pages/MultiMarketsPage').then(m => ({ default: m.MultiMarketsPage })));
+const MultiTradePage = lazy(() => import('./pages/MultiTradePage').then(m => ({ default: m.MultiTradePage })));
+const CreateMultiMarketPage = lazy(() => import('./pages/CreateMultiMarketPage').then(m => ({ default: m.CreateMultiMarketPage })));
 
 function App() {
   useEffect(() => {
@@ -55,94 +57,96 @@ function App() {
                   <TestnetWarningBanner />
                   <Header />
                 <main className="flex-1">
-                  <Routes>
-                    <Route path="/" element={<LandingPage />} />
-                    <Route path="/markets" element={
-                      <PageErrorBoundary pageName="Markets">
-                        <MarketsPage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/trade/:id" element={
-                      <PageErrorBoundary pageName="Trade">
-                        <TradePage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/portfolio" element={
-                      <PageErrorBoundary pageName="Portfolio">
-                        <PortfolioPage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/watchlist" element={
-                      <PageErrorBoundary pageName="Watchlist">
-                        <WatchlistPage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/recently-viewed" element={
-                      <PageErrorBoundary pageName="Recently Viewed">
-                        <RecentlyViewedPage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/token" element={
-                      <PageErrorBoundary pageName="Token">
-                        <TokenPage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/staking" element={
-                      <PageErrorBoundary pageName="Staking">
-                        <StakingPage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/governance" element={
-                      <PageErrorBoundary pageName="Governance">
-                        <GovernancePage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/transactions" element={
-                      <PageErrorBoundary pageName="Transactions">
-                        <TransactionHistoryPage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/create-market" element={
-                      <PageErrorBoundary pageName="Create Market">
-                        <CreateMarketPage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/oracle" element={
-                      <PageErrorBoundary pageName="Oracle">
-                        <OraclePage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/liquidity" element={
-                      <PageErrorBoundary pageName="Liquidity">
-                        <LiquidityPage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/analytics" element={
-                      <PageErrorBoundary pageName="Analytics">
-                        <AnalyticsPage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/leaderboard" element={
-                      <PageErrorBoundary pageName="Leaderboard">
-                        <LeaderboardPage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/multi-markets" element={
-                      <PageErrorBoundary pageName="Multi Markets">
-                        <MultiMarketsPage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/multi-trade/:id" element={
-                      <PageErrorBoundary pageName="Multi Trade">
-                        <MultiTradePage />
-                      </PageErrorBoundary>
-                    } />
-                    <Route path="/create-multi-market" element={
-                      <PageErrorBoundary pageName="Create Multi Market">
-                        <CreateMultiMarketPage />
-                      </PageErrorBoundary>
-                    } />
-                  </Routes>
+                  <Suspense fallback={<LoadingState />}>
+                    <Routes>
+                      <Route path="/" element={<LandingPage />} />
+                      <Route path="/markets" element={
+                        <PageErrorBoundary pageName="Markets">
+                          <MarketsPage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/trade/:id" element={
+                        <PageErrorBoundary pageName="Trade">
+                          <TradePage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/portfolio" element={
+                        <PageErrorBoundary pageName="Portfolio">
+                          <PortfolioPage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/watchlist" element={
+                        <PageErrorBoundary pageName="Watchlist">
+                          <WatchlistPage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/recently-viewed" element={
+                        <PageErrorBoundary pageName="Recently Viewed">
+                          <RecentlyViewedPage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/token" element={
+                        <PageErrorBoundary pageName="Token">
+                          <TokenPage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/staking" element={
+                        <PageErrorBoundary pageName="Staking">
+                          <StakingPage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/governance" element={
+                        <PageErrorBoundary pageName="Governance">
+                          <GovernancePage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/transactions" element={
+                        <PageErrorBoundary pageName="Transactions">
+                          <TransactionHistoryPage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/create-market" element={
+                        <PageErrorBoundary pageName="Create Market">
+                          <CreateMarketPage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/oracle" element={
+                        <PageErrorBoundary pageName="Oracle">
+                          <OraclePage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/liquidity" element={
+                        <PageErrorBoundary pageName="Liquidity">
+                          <LiquidityPage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/analytics" element={
+                        <PageErrorBoundary pageName="Analytics">
+                          <AnalyticsPage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/leaderboard" element={
+                        <PageErrorBoundary pageName="Leaderboard">
+                          <LeaderboardPage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/multi-markets" element={
+                        <PageErrorBoundary pageName="Multi Markets">
+                          <MultiMarketsPage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/multi-trade/:id" element={
+                        <PageErrorBoundary pageName="Multi Trade">
+                          <MultiTradePage />
+                        </PageErrorBoundary>
+                      } />
+                      <Route path="/create-multi-market" element={
+                        <PageErrorBoundary pageName="Create Multi Market">
+                          <CreateMultiMarketPage />
+                        </PageErrorBoundary>
+                      } />
+                    </Routes>
+                  </Suspense>
                 </main>
                 <Footer />
                 <MobileBottomNav />


### PR DESCRIPTION
Changes in 
App.tsx
:

Added lazy and Suspense to the React import
Added LoadingState import from ./components/Loading as the Suspense fallback
Removed all 18 static page imports
Replaced each with a lazy() call using the named-export pattern: lazy(() => import('./pages/X').then(m => ({ default: m.X })))
Wrapped <Routes> with <Suspense fallback={<LoadingState />}>

Closes #166