### PR TITLE
Fix/replace any types rate limit dashboard

### DIFF
--- a/frontend/src/components/RateLimitMonitoringDashboard.tsx
+++ b/frontend/src/components/RateLimitMonitoringDashboard.tsx
@@ -32,7 +32,7 @@ interface MonitoringReport {
 type AlertSeverity = 'low' | 'medium' | 'high' | 'critical';
 
 export const RateLimitMonitoringDashboard: React.FC = () => {
-  const [report, setReport] = useState<any>(null);
+  const [report, setReport] = useState<MonitoringReport | null>(null);
   const [alerts, setAlerts] = useState<RateLimitAlert[]>([]);
   const [selectedSeverity, setSelectedSeverity] = useState<string>('all');
 

--- a/frontend/src/components/RateLimitMonitoringDashboard.tsx
+++ b/frontend/src/components/RateLimitMonitoringDashboard.tsx
@@ -29,6 +29,8 @@ interface MonitoringReport {
   topUsers: TopUserItem[];
 }
 
+type AlertSeverity = 'low' | 'medium' | 'high' | 'critical';
+
 export const RateLimitMonitoringDashboard: React.FC = () => {
   const [report, setReport] = useState<any>(null);
   const [alerts, setAlerts] = useState<RateLimitAlert[]>([]);

--- a/frontend/src/components/RateLimitMonitoringDashboard.tsx
+++ b/frontend/src/components/RateLimitMonitoringDashboard.tsx
@@ -9,6 +9,11 @@ interface TopActionItem {
   count: number;
 }
 
+interface TopUserItem {
+  userId: string;
+  violations: number;
+}
+
 export const RateLimitMonitoringDashboard: React.FC = () => {
   const [report, setReport] = useState<any>(null);
   const [alerts, setAlerts] = useState<RateLimitAlert[]>([]);

--- a/frontend/src/components/RateLimitMonitoringDashboard.tsx
+++ b/frontend/src/components/RateLimitMonitoringDashboard.tsx
@@ -21,6 +21,14 @@ interface AlertsBySeverity {
   critical: number;
 }
 
+interface MonitoringReport {
+  totalViolations: number;
+  uniqueUsers: number;
+  alertsBySeverity: AlertsBySeverity;
+  topActions: TopActionItem[];
+  topUsers: TopUserItem[];
+}
+
 export const RateLimitMonitoringDashboard: React.FC = () => {
   const [report, setReport] = useState<any>(null);
   const [alerts, setAlerts] = useState<RateLimitAlert[]>([]);

--- a/frontend/src/components/RateLimitMonitoringDashboard.tsx
+++ b/frontend/src/components/RateLimitMonitoringDashboard.tsx
@@ -4,6 +4,11 @@ import { RateLimitAlert } from '@/services/RateLimitMonitoringService';
 import { RateLimitAction } from '@/types/rateLimit';
 import { getActionDisplayName } from '@/utils/rateLimitHelpers';
 
+interface TopActionItem {
+  action: RateLimitAction;
+  count: number;
+}
+
 export const RateLimitMonitoringDashboard: React.FC = () => {
   const [report, setReport] = useState<any>(null);
   const [alerts, setAlerts] = useState<RateLimitAlert[]>([]);

--- a/frontend/src/components/RateLimitMonitoringDashboard.tsx
+++ b/frontend/src/components/RateLimitMonitoringDashboard.tsx
@@ -113,7 +113,7 @@ export const RateLimitMonitoringDashboard: React.FC = () => {
         <div className="bg-white p-4 rounded-lg shadow">
           <h2 className="text-lg font-bold mb-4">Top Violating Actions</h2>
           <div className="space-y-2">
-            {report.topActions.map((item: any) => (
+            {report.topActions.map((item: TopActionItem) => (
               <div
                 key={item.action}
                 className="flex justify-between items-center p-2 border rounded"

--- a/frontend/src/components/RateLimitMonitoringDashboard.tsx
+++ b/frontend/src/components/RateLimitMonitoringDashboard.tsx
@@ -130,7 +130,7 @@ export const RateLimitMonitoringDashboard: React.FC = () => {
         <div className="bg-white p-4 rounded-lg shadow">
           <h2 className="text-lg font-bold mb-4">Top Violators</h2>
           <div className="space-y-2">
-            {report.topUsers.map((user: any, index: number) => (
+            {report.topUsers.map((user: TopUserItem, index: number) => (
               <div
                 key={user.userId}
                 className="flex justify-between items-center p-2 border rounded"

--- a/frontend/src/components/RateLimitMonitoringDashboard.tsx
+++ b/frontend/src/components/RateLimitMonitoringDashboard.tsx
@@ -14,6 +14,13 @@ interface TopUserItem {
   violations: number;
 }
 
+interface AlertsBySeverity {
+  low: number;
+  medium: number;
+  high: number;
+  critical: number;
+}
+
 export const RateLimitMonitoringDashboard: React.FC = () => {
   const [report, setReport] = useState<any>(null);
   const [alerts, setAlerts] = useState<RateLimitAlert[]>([]);

--- a/frontend/src/components/RateLimitMonitoringDashboard.tsx
+++ b/frontend/src/components/RateLimitMonitoringDashboard.tsx
@@ -50,7 +50,7 @@ export const RateLimitMonitoringDashboard: React.FC = () => {
       selectedSeverity === 'all'
         ? rateLimitMonitoringService.getActiveAlerts()
         : rateLimitMonitoringService.getActiveAlerts(
-            selectedSeverity as any
+            selectedSeverity as AlertSeverity
           );
     setAlerts(newAlerts);
   };

--- a/frontend/src/components/RateLimitMonitoringDashboard.tsx
+++ b/frontend/src/components/RateLimitMonitoringDashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { rateLimitMonitoringService } from '@/services/RateLimitMonitoringService';
 import { RateLimitAlert } from '@/services/RateLimitMonitoringService';
+import { RateLimitAction } from '@/types/rateLimit';
 import { getActionDisplayName } from '@/utils/rateLimitHelpers';
 
 export const RateLimitMonitoringDashboard: React.FC = () => {


### PR DESCRIPTION
Summary of what was changed in RateLimitMonitoringDashboard.tsx:

Added RateLimitAction import from @/types/rateLimit
Defined TopActionItem interface — { action: RateLimitAction; count: number }
Defined TopUserItem interface — { userId: string; violations: number }
Defined AlertsBySeverity interface — { low, medium, high, critical: number }
Defined MonitoringReport interface — the full shape of generateReport() return value
Defined AlertSeverity type alias — 'low' | 'medium' | 'high' | 'critical'
Replaced useState<any>(null) → useState<MonitoringReport | null>(null)
Replaced selectedSeverity as any → selectedSeverity as AlertSeverity
Replaced (item: any) → (item: TopActionItem) in topActions.map
Replaced (user: any) → (user: TopUserItem) in topUsers.map

Closes #144